### PR TITLE
Small amount of cleaning in Packet Handlers

### DIFF
--- a/MapleServer2/PacketHandlers/Common/CommonPacketHandler.cs
+++ b/MapleServer2/PacketHandlers/Common/CommonPacketHandler.cs
@@ -7,7 +7,7 @@ using NLog;
 
 namespace MapleServer2.PacketHandlers.Common;
 
-public abstract class CommonPacketHandler : IPacketHandler<LoginSession>, IPacketHandler<GameSession>
+internal abstract class CommonPacketHandler : IPacketHandler<LoginSession>, IPacketHandler<GameSession>
 {
     public abstract RecvOp OpCode { get; }
 

--- a/MapleServer2/PacketHandlers/Common/HeartbeatHandler.cs
+++ b/MapleServer2/PacketHandlers/Common/HeartbeatHandler.cs
@@ -4,7 +4,7 @@ using MapleServer2.Servers.Login;
 
 namespace MapleServer2.PacketHandlers.Common;
 
-public abstract class HeartbeatHandler : CommonPacketHandler
+internal abstract class HeartbeatHandler : CommonPacketHandler
 {
     public override RecvOp OpCode => RecvOp.RESPONSE_HEARTBEAT;
 

--- a/MapleServer2/PacketHandlers/Common/LogSendHandler.cs
+++ b/MapleServer2/PacketHandlers/Common/LogSendHandler.cs
@@ -6,7 +6,7 @@ using MapleServer2.Network;
 namespace MapleServer2.PacketHandlers.Common;
 
 // Note: socket_exception debug offset includes +6 bytes from encrypted header
-public class LogSendHandler : CommonPacketHandler
+internal sealed class LogSendHandler : CommonPacketHandler
 {
     public override RecvOp OpCode => RecvOp.LOG_SEND;
 

--- a/MapleServer2/PacketHandlers/Common/QuitHandler.cs
+++ b/MapleServer2/PacketHandlers/Common/QuitHandler.cs
@@ -7,7 +7,7 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Common;
 
-public class QuitHandler : CommonPacketHandler
+internal sealed class QuitHandler : CommonPacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_QUIT;
     private readonly IPEndPoint LoginEndpoint;

--- a/MapleServer2/PacketHandlers/Common/ResponseKeyHandler.cs
+++ b/MapleServer2/PacketHandlers/Common/ResponseKeyHandler.cs
@@ -11,7 +11,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Common;
 
-public class ResponseKeyHandler : CommonPacketHandler
+internal sealed class ResponseKeyHandler : CommonPacketHandler
 {
     public override RecvOp OpCode => RecvOp.RESPONSE_KEY;
 

--- a/MapleServer2/PacketHandlers/Common/ResponseVersionHandler.cs
+++ b/MapleServer2/PacketHandlers/Common/ResponseVersionHandler.cs
@@ -7,7 +7,7 @@ using MapleServer2.Servers.Login;
 
 namespace MapleServer2.PacketHandlers.Common;
 
-public class ResponseVersionHandler : CommonPacketHandler
+internal sealed class ResponseVersionHandler : CommonPacketHandler
 {
     public override RecvOp OpCode => RecvOp.RESPONSE_VERSION;
 

--- a/MapleServer2/PacketHandlers/Common/SystemInfoHandler.cs
+++ b/MapleServer2/PacketHandlers/Common/SystemInfoHandler.cs
@@ -4,7 +4,7 @@ using MapleServer2.Network;
 
 namespace MapleServer2.PacketHandlers.Common;
 
-public class SystemInfoHandler : CommonPacketHandler
+internal sealed class SystemInfoHandler : CommonPacketHandler
 {
     public override RecvOp OpCode => RecvOp.SYSTEM_INFO;
 

--- a/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
@@ -17,66 +17,66 @@ public class BeautyHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.BEAUTY;
 
-    private enum BeautyMode : byte
+    private static class BeautyOperations
     {
-        LoadShop = 0x0,
-        NewBeauty = 0x3,
-        ModifyExistingBeauty = 0x5,
-        ModifySkin = 0x6,
-        RandomHair = 0x7,
-        Teleport = 0xA,
-        ChooseRandomHair = 0xC,
-        SaveHair = 0x10,
-        DeleteSavedHair = 0x12,
-        ChangeToSavedHair = 0x15,
-        DyeItem = 0x16,
-        BeautyVoucher = 0x17
+        public const byte LoadShop = 0x0;
+        public const byte NewBeauty = 0x3;
+        public const byte ModifyExistingBeauty = 0x5;
+        public const byte ModifySkin = 0x6;
+        public const byte RandomHair = 0x7;
+        public const byte Teleport = 0xA;
+        public const byte ChooseRandomHair = 0xC;
+        public const byte SaveHair = 0x10;
+        public const byte DeleteSavedHair = 0x12;
+        public const byte ChangeToSavedHair = 0x15;
+        public const byte DyeItem = 0x16;
+        public const byte BeautyVoucher = 0x17;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        BeautyMode mode = (BeautyMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
-            case BeautyMode.LoadShop:
+            case BeautyOperations.LoadShop:
                 HandleLoadShop(session, packet);
                 break;
-            case BeautyMode.NewBeauty:
+            case BeautyOperations.NewBeauty:
                 HandleNewBeauty(session, packet);
                 break;
-            case BeautyMode.ModifyExistingBeauty:
+            case BeautyOperations.ModifyExistingBeauty:
                 HandleModifyExistingBeauty(session, packet);
                 break;
-            case BeautyMode.ModifySkin:
+            case BeautyOperations.ModifySkin:
                 HandleModifySkin(session, packet);
                 break;
-            case BeautyMode.RandomHair:
+            case BeautyOperations.RandomHair:
                 HandleRandomHair(session, packet);
                 break;
-            case BeautyMode.ChooseRandomHair:
+            case BeautyOperations.ChooseRandomHair:
                 HandleChooseRandomHair(session, packet);
                 break;
-            case BeautyMode.SaveHair:
+            case BeautyOperations.SaveHair:
                 HandleSaveHair(session, packet);
                 break;
-            case BeautyMode.Teleport:
+            case BeautyOperations.Teleport:
                 HandleTeleport(session, packet);
                 break;
-            case BeautyMode.DeleteSavedHair:
+            case BeautyOperations.DeleteSavedHair:
                 HandleDeleteSavedHair(session, packet);
                 break;
-            case BeautyMode.ChangeToSavedHair:
+            case BeautyOperations.ChangeToSavedHair:
                 HandleChangeToSavedHair(session, packet);
                 break;
-            case BeautyMode.DyeItem:
+            case BeautyOperations.DyeItem:
                 HandleDyeItem(session, packet);
                 break;
-            case BeautyMode.BeautyVoucher:
+            case BeautyOperations.BeautyVoucher:
                 HandleBeautyVoucher(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(typeof(BeautyHandler), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
@@ -13,7 +13,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class BeautyHandler : GamePacketHandler
+internal sealed class BeautyHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.BEAUTY;
 

--- a/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
@@ -35,9 +35,9 @@ public class BeautyHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
             case BeautyOperations.LoadShop:
                 HandleLoadShop(session, packet);
@@ -76,7 +76,7 @@ public class BeautyHandler : GamePacketHandler
                 HandleBeautyVoucher(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(typeof(BeautyHandler), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/BlackMarketHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BlackMarketHandler.cs
@@ -12,7 +12,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class BlackMarketHandler : GamePacketHandler
+internal sealed class BlackMarketHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.BLACK_MARKET;
 
@@ -26,7 +26,7 @@ public class BlackMarketHandler : GamePacketHandler
         public const byte PrepareListing = 0x8;
     }
 
-    private static class BlackMarketError
+    private static class BlackMarketErrors
     {
         public const byte FailedToListItem = 0x05;
         public const byte ItemNotInInventory = 0x0E;
@@ -105,7 +105,7 @@ public class BlackMarketHandler : GamePacketHandler
 
         if (!session.Player.Inventory.Items.ContainsKey(itemUid))
         {
-            session.Send(BlackMarketPacket.Error(BlackMarketError.ItemNotInInventory));
+            session.Send(BlackMarketPacket.Error(BlackMarketErrors.ItemNotInInventory));
             return;
         }
 
@@ -222,13 +222,13 @@ public class BlackMarketHandler : GamePacketHandler
 
         if (listing.OwnerAccountId == session.Player.AccountId)
         {
-            session.Send(BlackMarketPacket.Error(BlackMarketError.CannotPurchaseOwnItems));
+            session.Send(BlackMarketPacket.Error(BlackMarketErrors.CannotPurchaseOwnItems));
             return;
         }
 
         if (listing.Item.Amount < amount)
         {
-            session.Send(BlackMarketPacket.Error(BlackMarketError.QuantityNotAvailable));
+            session.Send(BlackMarketPacket.Error(BlackMarketErrors.QuantityNotAvailable));
             return;
         }
 

--- a/MapleServer2/PacketHandlers/Game/BlackMarketHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BlackMarketHandler.cs
@@ -16,56 +16,56 @@ public class BlackMarketHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.BLACK_MARKET;
 
-    private enum BlackMarketMode : byte
+    private static class BlackMarketOperation
     {
-        Open = 0x1,
-        CreateListing = 0x2,
-        CancelListing = 0x3,
-        Search = 0x4,
-        Purchase = 0x5,
-        PrepareListing = 0x8
+        public const byte Open = 0x1;
+        public const byte CreateListing = 0x2;
+        public const byte CancelListing = 0x3;
+        public const byte Search = 0x4;
+        public const byte Purchase = 0x5;
+        public const byte PrepareListing = 0x8;
     }
 
-    private enum BlackMarketError
+    private static class BlackMarketError
     {
-        FailedToListItem = 0x05,
-        ItemNotInInventory = 0x0E,
-        ItemCannotBeListed = 0x20,
-        OneMinuteRestriction = 0x25,
-        Fatigue = 0x26,
-        CannotUseBlackMarket = 0x27,
-        QuantityNotAvailable = 0x29,
-        CannotPurchaseOwnItems = 0x2A,
-        RequiredLevelToList = 0x2B,
-        RequiredLevelToBuy = 0x2C
+        public const byte FailedToListItem = 0x05;
+        public const byte ItemNotInInventory = 0x0E;
+        public const byte ItemCannotBeListed = 0x20;
+        public const byte OneMinuteRestriction = 0x25;
+        public const byte Fatigue = 0x26;
+        public const byte CannotUseBlackMarket = 0x27;
+        public const byte QuantityNotAvailable = 0x29;
+        public const byte CannotPurchaseOwnItems = 0x2A;
+        public const byte RequiredLevelToList = 0x2B;
+        public const byte RequiredLevelToBuy = 0x2C;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        BlackMarketMode mode = (BlackMarketMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
-            case BlackMarketMode.Open:
+            case BlackMarketOperation.Open:
                 HandleOpen(session);
                 break;
-            case BlackMarketMode.CreateListing:
+            case BlackMarketOperation.CreateListing:
                 HandleCreateListing(session, packet);
                 break;
-            case BlackMarketMode.CancelListing:
+            case BlackMarketOperation.CancelListing:
                 HandleCancelListing(session, packet);
                 break;
-            case BlackMarketMode.Search:
+            case BlackMarketOperation.Search:
                 HandleSearch(session, packet);
                 break;
-            case BlackMarketMode.Purchase:
+            case BlackMarketOperation.Purchase:
                 HandlePurchase(session, packet);
                 break;
-            case BlackMarketMode.PrepareListing:
+            case BlackMarketOperation.PrepareListing:
                 HandlePrepareListing(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(typeof(BlackMarketHandler), mode);
                 break;
         }
     }
@@ -105,7 +105,7 @@ public class BlackMarketHandler : GamePacketHandler
 
         if (!session.Player.Inventory.Items.ContainsKey(itemUid))
         {
-            session.Send(BlackMarketPacket.Error((int) BlackMarketError.ItemNotInInventory));
+            session.Send(BlackMarketPacket.Error(BlackMarketError.ItemNotInInventory));
             return;
         }
 
@@ -222,13 +222,13 @@ public class BlackMarketHandler : GamePacketHandler
 
         if (listing.OwnerAccountId == session.Player.AccountId)
         {
-            session.Send(BlackMarketPacket.Error((int) BlackMarketError.CannotPurchaseOwnItems));
+            session.Send(BlackMarketPacket.Error(BlackMarketError.CannotPurchaseOwnItems));
             return;
         }
 
         if (listing.Item.Amount < amount)
         {
-            session.Send(BlackMarketPacket.Error((int) BlackMarketError.QuantityNotAvailable));
+            session.Send(BlackMarketPacket.Error(BlackMarketError.QuantityNotAvailable));
             return;
         }
 

--- a/MapleServer2/PacketHandlers/Game/BlackMarketHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BlackMarketHandler.cs
@@ -16,7 +16,7 @@ public class BlackMarketHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.BLACK_MARKET;
 
-    private static class BlackMarketOperation
+    private static class BlackMarketOperations
     {
         public const byte Open = 0x1;
         public const byte CreateListing = 0x2;
@@ -42,30 +42,30 @@ public class BlackMarketHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
-            case BlackMarketOperation.Open:
+            case BlackMarketOperations.Open:
                 HandleOpen(session);
                 break;
-            case BlackMarketOperation.CreateListing:
+            case BlackMarketOperations.CreateListing:
                 HandleCreateListing(session, packet);
                 break;
-            case BlackMarketOperation.CancelListing:
+            case BlackMarketOperations.CancelListing:
                 HandleCancelListing(session, packet);
                 break;
-            case BlackMarketOperation.Search:
+            case BlackMarketOperations.Search:
                 HandleSearch(session, packet);
                 break;
-            case BlackMarketOperation.Purchase:
+            case BlackMarketOperations.Purchase:
                 HandlePurchase(session, packet);
                 break;
-            case BlackMarketOperation.PrepareListing:
+            case BlackMarketOperations.PrepareListing:
                 HandlePrepareListing(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(typeof(BlackMarketHandler), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/BonusGameHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BonusGameHandler.cs
@@ -10,28 +10,28 @@ public class BonusGameHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.BONUS_GAME;
 
-    private enum BonusGameType : byte
+    private static class BonusGameOperations
     {
-        Open = 0x00,
-        Spin = 0x02,
-        Close = 0x03
+        public const byte Open = 0x00;
+        public const byte Spin = 0x02;
+        public const byte Close = 0x03;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        BonusGameType mode = (BonusGameType) packet.ReadByte();
+        var mode = packet.ReadByte();
         switch (mode)
         {
-            case BonusGameType.Open:
+            case BonusGameOperations.Open:
                 HandleOpen(session, packet);
                 break;
-            case BonusGameType.Spin:
+            case BonusGameOperations.Spin:
                 HandleSpin(session);
                 break;
-            case BonusGameType.Close:
+            case BonusGameOperations.Close:
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(typeof(BonusGameHandler), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/BonusGameHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BonusGameHandler.cs
@@ -6,7 +6,7 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class BonusGameHandler : GamePacketHandler
+internal sealed class BonusGameHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.BONUS_GAME;
 

--- a/MapleServer2/PacketHandlers/Game/BonusGameHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BonusGameHandler.cs
@@ -19,8 +19,8 @@ public class BonusGameHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
-        switch (mode)
+        var operation = packet.ReadByte();
+        switch (operation)
         {
             case BonusGameOperations.Open:
                 HandleOpen(session, packet);
@@ -31,7 +31,7 @@ public class BonusGameHandler : GamePacketHandler
             case BonusGameOperations.Close:
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(typeof(BonusGameHandler), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/BreakableHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BreakableHandler.cs
@@ -5,7 +5,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class BreakableHandler : GamePacketHandler
+internal sealed class BreakableHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.BREAKABLE;
 

--- a/MapleServer2/PacketHandlers/Game/BuddyEmoteHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BuddyEmoteHandler.cs
@@ -7,7 +7,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class BuddyEmoteHandler : GamePacketHandler
+internal sealed class BuddyEmoteHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.BUDDY_EMOTE;
 

--- a/MapleServer2/PacketHandlers/Game/BuddyEmoteHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BuddyEmoteHandler.cs
@@ -11,42 +11,41 @@ public class BuddyEmoteHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.BUDDY_EMOTE;
 
-    private enum BuddyEmoteMode : byte
+    private static class BuddyEmoteOperations
     {
-        InviteBuddyEmote = 0x0,
-        InviteBuddyEmoteConfirm = 0x1,
-        LearnEmote = 0x2,
-        AcceptEmote = 0x3,
-        DeclineEmote = 0x4,
-        StopEmote = 0x6
+        public const byte InviteBuddyEmote = 0x0;
+        public const byte InviteBuddyEmoteConfirm = 0x1;
+        public const byte LearnEmote = 0x2;
+        public const byte AcceptEmote = 0x3;
+        public const byte DeclineEmote = 0x4;
+        public const byte StopEmote = 0x6;
     }
-
     public override void Handle(GameSession session, PacketReader packet)
     {
-        BuddyEmoteMode mode = (BuddyEmoteMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
-            case BuddyEmoteMode.InviteBuddyEmote:
+            case BuddyEmoteOperations.InviteBuddyEmote:
                 HandleInviteBuddyEmote(session, packet);
                 break;
-            case BuddyEmoteMode.InviteBuddyEmoteConfirm:
+            case BuddyEmoteOperations.InviteBuddyEmoteConfirm:
                 HandleInviteBuddyEmoteConfirm(session, packet);
                 break;
-            case BuddyEmoteMode.LearnEmote:
+            case BuddyEmoteOperations.LearnEmote:
                 HandleLearnEmote(session, packet);
                 break;
-            case BuddyEmoteMode.AcceptEmote:
+            case BuddyEmoteOperations.AcceptEmote:
                 HandleAcceptEmote(session, packet);
                 break;
-            case BuddyEmoteMode.DeclineEmote:
+            case BuddyEmoteOperations.DeclineEmote:
                 HandleDeclineEmote(session, packet);
                 break;
-            case BuddyEmoteMode.StopEmote:
+            case BuddyEmoteOperations.StopEmote:
                 HandleStopEmote(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(typeof(BuddyEmoteHandler), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/BuddyEmoteHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BuddyEmoteHandler.cs
@@ -22,9 +22,9 @@ public class BuddyEmoteHandler : GamePacketHandler
     }
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
             case BuddyEmoteOperations.InviteBuddyEmote:
                 HandleInviteBuddyEmote(session, packet);
@@ -45,7 +45,7 @@ public class BuddyEmoteHandler : GamePacketHandler
                 HandleStopEmote(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(typeof(BuddyEmoteHandler), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/BuddyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BuddyHandler.cs
@@ -9,7 +9,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class BuddyHandler : GamePacketHandler
+internal sealed class BuddyHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.BUDDY;
 
@@ -25,7 +25,7 @@ public class BuddyHandler : GamePacketHandler
         public const byte CancelRequest = 0x11;
     }
 
-    private static class BuddyNotice
+    private static class BuddyNotices
     {
         public const byte RequestSent = 0x0;
         public const byte CharacterNotFound = 0x1;
@@ -82,7 +82,7 @@ public class BuddyHandler : GamePacketHandler
 
         if (!DatabaseManager.Characters.NameExists(otherPlayerName))
         {
-            session.Send(BuddyPacket.Notice(BuddyNotice.CharacterNotFound, otherPlayerName));
+            session.Send(BuddyPacket.Notice(BuddyNotices.CharacterNotFound, otherPlayerName));
             return;
         }
 
@@ -95,31 +95,31 @@ public class BuddyHandler : GamePacketHandler
 
         if (targetPlayer.CharacterId == session.Player.CharacterId)
         {
-            session.Send(BuddyPacket.Notice(BuddyNotice.CannotAddSelf, targetPlayer.Name));
+            session.Send(BuddyPacket.Notice(BuddyNotices.CannotAddSelf, targetPlayer.Name));
             return;
         }
 
         if (session.Player.BuddyList.Count(b => !b.Blocked) >= 100) // 100 is friend limit
         {
-            session.Send(BuddyPacket.Notice(BuddyNotice.CannotAddFriends, targetPlayer.Name));
+            session.Send(BuddyPacket.Notice(BuddyNotices.CannotAddFriends, targetPlayer.Name));
             return;
         }
 
         if (targetPlayer.BuddyList.Count(b => !b.Blocked) >= 100)
         {
-            session.Send(BuddyPacket.Notice(BuddyNotice.OtherUserCannotAddFriends, targetPlayer.Name));
+            session.Send(BuddyPacket.Notice(BuddyNotices.OtherUserCannotAddFriends, targetPlayer.Name));
             return;
         }
 
         if (BuddyManager.IsBlocked(session.Player, targetPlayer))
         {
-            session.Send(BuddyPacket.Notice(BuddyNotice.DeclinedRequest, targetPlayer.Name));
+            session.Send(BuddyPacket.Notice(BuddyNotices.DeclinedRequest, targetPlayer.Name));
             return;
         }
 
         if (BuddyManager.IsFriend(session.Player, targetPlayer))
         {
-            session.Send(BuddyPacket.Notice(BuddyNotice.AlreadyFriends, targetPlayer.Name));
+            session.Send(BuddyPacket.Notice(BuddyNotices.AlreadyFriends, targetPlayer.Name));
             return;
         }
 
@@ -130,7 +130,7 @@ public class BuddyHandler : GamePacketHandler
         GameServer.BuddyManager.AddBuddy(buddyTargetPlayer);
         session.Player.BuddyList.Add(buddy);
 
-        session.Send(BuddyPacket.Notice(BuddyNotice.RequestSent, targetPlayer.Name));
+        session.Send(BuddyPacket.Notice(BuddyNotices.RequestSent, targetPlayer.Name));
         session.Send(BuddyPacket.AddToList(buddy));
 
         if (targetPlayer.Session != null && targetPlayer.Session.Connected())
@@ -235,13 +235,13 @@ public class BuddyHandler : GamePacketHandler
 
         if (session.Player.BuddyList.Count(b => b.Blocked) >= 100) // 100 is block limit
         {
-            session.Send(BuddyPacket.Notice(BuddyNotice.CannotBlock, targetName));
+            session.Send(BuddyPacket.Notice(BuddyNotices.CannotBlock, targetName));
             return;
         }
 
         if (!DatabaseManager.Characters.NameExists(targetName))
         {
-            session.Send(BuddyPacket.Notice(BuddyNotice.CharacterNotFound, targetName));
+            session.Send(BuddyPacket.Notice(BuddyNotices.CharacterNotFound, targetName));
             return;
         }
 

--- a/MapleServer2/PacketHandlers/Game/BuddyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BuddyHandler.cs
@@ -41,9 +41,9 @@ public class BuddyHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
             case BuddyOperations.SendRequest:
                 HandleSendRequest(session, packet);
@@ -70,7 +70,7 @@ public class BuddyHandler : GamePacketHandler
                 HandleCancelRequest(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(typeof(BuddyHandler), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/BuildModeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BuildModeHandler.cs
@@ -7,7 +7,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class BuildModeHandler : GamePacketHandler
+internal sealed class BuildModeHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_SET_BUILD_MODE;
 
@@ -17,7 +17,7 @@ public class BuildModeHandler : GamePacketHandler
         public const byte Start = 0x1;
     }
 
-    public static class BuildModeType
+    public static class BuildModeTypes
     {
         public const byte Stop = 0x0;
         public const byte House = 0x1;
@@ -48,7 +48,7 @@ public class BuildModeHandler : GamePacketHandler
         {
             return;
         }
-        session.FieldManager.BroadcastPacket(BuildModePacket.Use(session.Player.FieldPlayer, BuildModeType.Stop));
+        session.FieldManager.BroadcastPacket(BuildModePacket.Use(session.Player.FieldPlayer, BuildModeTypes.Stop));
         session.FieldManager.BroadcastPacket(GuideObjectPacket.Remove(session.Player.Guide));
         session.FieldManager.RemoveGuide(session.Player.Guide);
         session.Player.Guide = null; // remove guide from player
@@ -75,6 +75,6 @@ public class BuildModeHandler : GamePacketHandler
         session.FieldManager.AddGuide(fieldGuide);
 
         session.FieldManager.BroadcastPacket(GuideObjectPacket.Add(fieldGuide));
-        session.FieldManager.BroadcastPacket(BuildModePacket.Use(session.Player.FieldPlayer, BuildModeType.House, furnishingItemId, furnishingItemUid));
+        session.FieldManager.BroadcastPacket(BuildModePacket.Use(session.Player.FieldPlayer, BuildModeTypes.House, furnishingItemId, furnishingItemUid));
     }
 }

--- a/MapleServer2/PacketHandlers/Game/BuildModeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BuildModeHandler.cs
@@ -11,33 +11,33 @@ public class BuildModeHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_SET_BUILD_MODE;
 
-    private enum BuildModeMode : byte
+    private static class BuildModeOperation
     {
-        Stop = 0x0,
-        Start = 0x1
+        public const byte Stop = 0x0;
+        public const byte Start = 0x1;
     }
 
-    public enum BuildModeType : byte
+    public static class BuildModeType
     {
-        Stop = 0x0,
-        House = 0x1,
-        Liftables = 0x2,
+        public const byte Stop = 0x0;
+        public const byte House = 0x1;
+        public const byte Liftables = 0x2;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        BuildModeMode mode = (BuildModeMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
-            case BuildModeMode.Stop:
+            case BuildModeOperation.Stop:
                 HandleStop(session);
                 break;
-            case BuildModeMode.Start:
+            case BuildModeOperation.Start:
                 HandleStart(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(typeof(BuildModeHandler), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/BuildModeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BuildModeHandler.cs
@@ -11,7 +11,7 @@ public class BuildModeHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_SET_BUILD_MODE;
 
-    private static class BuildModeOperation
+    private static class BuildModeOperations
     {
         public const byte Stop = 0x0;
         public const byte Start = 0x1;
@@ -30,14 +30,14 @@ public class BuildModeHandler : GamePacketHandler
 
         switch (mode)
         {
-            case BuildModeOperation.Stop:
+            case BuildModeOperations.Stop:
                 HandleStop(session);
                 break;
-            case BuildModeOperation.Start:
+            case BuildModeOperations.Start:
                 HandleStart(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(typeof(BuildModeHandler), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/CardReverseGameHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/CardReverseGameHandler.cs
@@ -13,30 +13,30 @@ public class CardReverseGameHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.CARD_REVERSE_GAME;
 
-    private enum CardReverseGameMode : byte
+    private static class CardReverseGameOperations
     {
-        Open = 0x0,
-        Mix = 0x1,
-        Select = 0x2
+        public const byte Open = 0x0;
+        public const byte Mix = 0x1;
+        public const byte Select = 0x2;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        CardReverseGameMode mode = (CardReverseGameMode) packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
-            case CardReverseGameMode.Open:
+            case CardReverseGameOperations.Open:
                 HandleOpen(session);
                 break;
-            case CardReverseGameMode.Mix:
+            case CardReverseGameOperations.Mix:
                 HandleMix(session);
                 break;
-            case CardReverseGameMode.Select:
+            case CardReverseGameOperations.Select:
                 HandleSelect(session);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/CardReverseGameHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/CardReverseGameHandler.cs
@@ -9,7 +9,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class CardReverseGameHandler : GamePacketHandler
+internal sealed class CardReverseGameHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.CARD_REVERSE_GAME;
 

--- a/MapleServer2/PacketHandlers/Game/ChangeAttributesHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ChangeAttributesHandler.cs
@@ -12,23 +12,26 @@ public class ChangeAttributesHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.CHANGE_ATTRIBUTES;
 
-    private enum ChangeAttributesMode : byte
+    private static class ChangeAttributesMode
     {
-        ChangeAttributes = 0,
-        SelectNewAttributes = 2
+        public const byte ChangeAttributes = 0x0;
+        public const byte SelectNewAttributes = 0x02;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ChangeAttributesMode function = (ChangeAttributesMode) packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (function)
+        switch (operation)
         {
             case ChangeAttributesMode.ChangeAttributes:
                 HandleChangeAttributes(session, packet);
                 break;
             case ChangeAttributesMode.SelectNewAttributes:
                 HandleSelectNewAttributes(session, packet);
+                break;
+            default:
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/ChangeAttributesHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ChangeAttributesHandler.cs
@@ -8,7 +8,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class ChangeAttributesHandler : GamePacketHandler
+internal sealed class ChangeAttributesHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.CHANGE_ATTRIBUTES;
 

--- a/MapleServer2/PacketHandlers/Game/ChangeAttributesScrollHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ChangeAttributesScrollHandler.cs
@@ -6,19 +6,19 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class ChangeAttributesScrollHandler : GamePacketHandler
+internal sealed class ChangeAttributesScrollHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.CHANGE_ATTRIBUTES_SCROLL;
 
-    private enum ChangeAttributeMode : byte
+    private static class ChangeAttributeMode
     {
-        ChangeAttributes = 1,
-        SelectNewAttributes = 3
+        public const byte ChangeAttributes = 1;
+        public const byte SelectNewAttributes = 3;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ChangeAttributeMode mode = (ChangeAttributeMode) packet.ReadByte();
+        var mode = packet.ReadByte();
         switch (mode)
         {
             case ChangeAttributeMode.ChangeAttributes:
@@ -28,7 +28,7 @@ public class ChangeAttributesScrollHandler : GamePacketHandler
                 HandleSelectNewAttributes(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/ChannelHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ChannelHandler.cs
@@ -6,7 +6,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class ChannelHandler : GamePacketHandler
+internal sealed class ChannelHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.CHANNEL;
 

--- a/MapleServer2/PacketHandlers/Game/CharacterInfoHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/CharacterInfoHandler.cs
@@ -5,7 +5,7 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class CharacterInfoHandler : GamePacketHandler
+internal sealed class CharacterInfoHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.CHARACTER_INFO;
 

--- a/MapleServer2/PacketHandlers/Game/CharacterNameChangeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/CharacterNameChangeHandler.cs
@@ -6,7 +6,7 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class CharacterNameChangeHandler : GamePacketHandler
+internal sealed class CharacterNameChangeHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.CHECK_CHAR_NAME;
 

--- a/MapleServer2/PacketHandlers/Game/ChatStickerHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ChatStickerHandler.cs
@@ -10,38 +10,38 @@ public class ChatStickerHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.CHAT_STICKER;
 
-    private enum ChatStickerMode : byte
+    private static class ChatStickerOperations
     {
-        OpenWindow = 0x1,
-        UseSticker = 0x3,
-        GroupChatSticker = 0x4,
-        Favorite = 0x5,
-        Unfavorite = 0x6
+        public const byte OpenWindow = 0x1;
+        public const byte UseSticker = 0x3;
+        public const byte GroupChatSticker = 0x4;
+        public const byte Favorite = 0x5;
+        public const byte Unfavorite = 0x6;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ChatStickerMode mode = (ChatStickerMode) packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
-            case ChatStickerMode.OpenWindow:
+            case ChatStickerOperations.OpenWindow:
                 HandleOpenWindow( /*session, packet*/);
                 break;
-            case ChatStickerMode.UseSticker:
+            case ChatStickerOperations.UseSticker:
                 HandleUseSticker(session, packet);
                 break;
-            case ChatStickerMode.GroupChatSticker:
+            case ChatStickerOperations.GroupChatSticker:
                 HandleGroupChatSticker(session, packet);
                 break;
-            case ChatStickerMode.Favorite:
+            case ChatStickerOperations.Favorite:
                 HandleFavorite(session, packet);
                 break;
-            case ChatStickerMode.Unfavorite:
+            case ChatStickerOperations.Unfavorite:
                 HandleUnfavorite(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/ChatStickerHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ChatStickerHandler.cs
@@ -6,7 +6,7 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class ChatStickerHandler : GamePacketHandler
+internal sealed class ChatStickerHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.CHAT_STICKER;
 

--- a/MapleServer2/PacketHandlers/Game/ClientTickSyncHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ClientTickSyncHandler.cs
@@ -4,7 +4,7 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class ClientTickSyncHandler : GamePacketHandler
+internal sealed class ClientTickSyncHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.RESPONSE_CLIENTTICK_SYNC;
 

--- a/MapleServer2/PacketHandlers/Game/ClubHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ClubHandler.cs
@@ -7,7 +7,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class ClubHandler : GamePacketHandler
+internal sealed class ClubHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.CLUB;
 

--- a/MapleServer2/PacketHandlers/Game/ClubHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ClubHandler.cs
@@ -11,20 +11,20 @@ public class ClubHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.CLUB;
 
-    private enum ClubMode : byte
+    private static class ClubMode
     {
-        Create = 0x1,
-        Join = 0x3,
-        SendInvite = 0x6,
-        InviteResponse = 0x8,
-        Leave = 0xA,
-        Buff = 0xD,
-        Rename = 0xE
+        public const byte Create = 0x1;
+        public const byte Join = 0x3;
+        public const byte SendInvite = 0x6;
+        public const byte InviteResponse = 0x8;
+        public const byte Leave = 0xA;
+        public const byte Buff = 0xD;
+        public const byte Rename = 0xE;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ClubMode mode = (ClubMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
@@ -50,7 +50,7 @@ public class ClubHandler : GamePacketHandler
                 HandleRename(packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/DungeonHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/DungeonHandler.cs
@@ -12,21 +12,21 @@ public class DungeonHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.ROOM_DUNGEON;
 
-    private enum DungeonMode : byte
+    private static class DungeonMode
     {
-        ResetDungeon = 0x01,
-        CreateDungeon = 0x02,
-        EnterDungeonButton = 0x03,
-        EnterDungeonPortal = 0x0A,
-        AddRewards = 0x8,
-        GetHelp = 0x10,
-        Veteran = 0x11,
-        Favorite = 0x19
+        public const byte ResetDungeon = 0x01;
+        public const byte CreateDungeon = 0x02;
+        public const byte EnterDungeonButton = 0x03;
+        public const byte EnterDungeonPortal = 0x0A;
+        public const byte AddRewards = 0x8;
+        public const byte GetHelp = 0x10;
+        public const byte Veteran = 0x11;
+        public const byte Favorite = 0x19;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        DungeonMode mode = (DungeonMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
@@ -52,7 +52,7 @@ public class DungeonHandler : GamePacketHandler
                 HandleFavorite(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/DungeonHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/DungeonHandler.cs
@@ -8,11 +8,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class DungeonHandler : GamePacketHandler
+internal sealed class DungeonHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.ROOM_DUNGEON;
 
-    private static class DungeonMode
+    private static class DungeonOperations
     {
         public const byte ResetDungeon = 0x01;
         public const byte CreateDungeon = 0x02;
@@ -26,33 +26,33 @@ public class DungeonHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operations = packet.ReadByte();
 
-        switch (mode)
+        switch (operations)
         {
-            case DungeonMode.EnterDungeonPortal:
+            case DungeonOperations.EnterDungeonPortal:
                 HandleEnterDungeonPortal(session);
                 break;
-            case DungeonMode.CreateDungeon:
+            case DungeonOperations.CreateDungeon:
                 HandleCreateDungeon(session, packet);
                 break;
-            case DungeonMode.EnterDungeonButton:
+            case DungeonOperations.EnterDungeonButton:
                 HandleEnterDungeonButton(session);
                 break;
-            case DungeonMode.AddRewards:
+            case DungeonOperations.AddRewards:
                 HandleAddRewards(session, packet);
                 break;
-            case DungeonMode.GetHelp:
+            case DungeonOperations.GetHelp:
                 HandleGetHelp(session, packet);
                 break;
-            case DungeonMode.Veteran:
+            case DungeonOperations.Veteran:
                 HandleVeteran(session, packet);
                 break;
-            case DungeonMode.Favorite:
+            case DungeonOperations.Favorite:
                 HandleFavorite(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operations);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/EmoteHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/EmoteHandler.cs
@@ -6,11 +6,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class EmoteHandler : GamePacketHandler
+internal sealed class EmoteHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.EMOTION;
 
-    private static class EmoteMode
+    private static class EmoteOperations
     {
         public const byte LearnEmote = 0x1;
         public const byte UseEmote = 0x2;
@@ -22,10 +22,10 @@ public class EmoteHandler : GamePacketHandler
 
         switch (mode)
         {
-            case EmoteMode.LearnEmote:
+            case EmoteOperations.LearnEmote:
                 HandleLearnEmote(session, packet);
                 break;
-            case EmoteMode.UseEmote:
+            case EmoteOperations.UseEmote:
                 HandleUseEmote(packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/EmoteHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/EmoteHandler.cs
@@ -10,15 +10,15 @@ public class EmoteHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.EMOTION;
 
-    private enum EmoteMode : byte
+    private static class EmoteMode
     {
-        LearnEmote = 0x1,
-        UseEmote = 0x2
+        public const byte LearnEmote = 0x1;
+        public const byte UseEmote = 0x2;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        EmoteMode mode = (EmoteMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
@@ -29,7 +29,7 @@ public class EmoteHandler : GamePacketHandler
                 HandleUseEmote(packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/EnterEventFieldHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/EnterEventFieldHandler.cs
@@ -6,7 +6,7 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class EnterEventFieldHandler : GamePacketHandler
+internal sealed class EnterEventFieldHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.ENTER_EVENTFIELD;
 

--- a/MapleServer2/PacketHandlers/Game/FallDamageHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FallDamageHandler.cs
@@ -6,7 +6,7 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class FallDamageHandler : GamePacketHandler
+internal sealed class FallDamageHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.STATE_FALL_DAMAGE;
 

--- a/MapleServer2/PacketHandlers/Game/FieldEnterHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FieldEnterHandler.cs
@@ -9,7 +9,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class FieldEnterHandler : GamePacketHandler
+internal sealed class FieldEnterHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.RESPONSE_FIELD_ENTER;
 

--- a/MapleServer2/PacketHandlers/Game/FileHashHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FileHashHandler.cs
@@ -4,7 +4,7 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class FileHashHandler : GamePacketHandler
+internal sealed class FileHashHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.FILE_HASH;
 

--- a/MapleServer2/PacketHandlers/Game/FishingHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FishingHandler.cs
@@ -15,13 +15,13 @@ public class FishingHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.FISHING;
 
-    private enum FishingMode : byte
+    private static class FishingMode
     {
-        PrepareFishing = 0x0,
-        Stop = 0x1,
-        Catch = 0x8,
-        Start = 0x9,
-        FailMinigame = 0xA
+        public const byte PrepareFishing = 0x0;
+        public const byte Stop = 0x1;
+        public const byte Catch = 0x8;
+        public const byte Start = 0x9;
+        public const byte FailMinigame = 0xA;
     }
 
     private enum FishingNotice : short
@@ -36,7 +36,7 @@ public class FishingHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        FishingMode mode = (FishingMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
@@ -56,7 +56,7 @@ public class FishingHandler : GamePacketHandler
                 HandleFailMinigame();
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/FishingHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FishingHandler.cs
@@ -11,11 +11,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class FishingHandler : GamePacketHandler
+internal sealed class FishingHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.FISHING;
 
-    private static class FishingMode
+    private static class FishingOperations
     {
         public const byte PrepareFishing = 0x0;
         public const byte Stop = 0x1;
@@ -24,39 +24,39 @@ public class FishingHandler : GamePacketHandler
         public const byte FailMinigame = 0xA;
     }
 
-    private enum FishingNotice : short
+    private static class FishingNotices
     {
-        CanOnlyFishNearWater = 0x1,
-        InvalidFishingRod = 0x2,
-        MasteryTooLowForMap = 0x3,
-        CannotFishHere = 0x4,
-        MasteryTooLowForRod = 0x6,
-        GearOrMiscInventoryFull = 0x7
+        public const short CanOnlyFishNearWater = 0x1;
+        public const short InvalidFishingRod = 0x2;
+        public const short MasteryTooLowForMap = 0x3;
+        public const short CannotFishHere = 0x4;
+        public const short MasteryTooLowForRod = 0x6;
+        public const short GearOrMiscInventoryFull = 0x7;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
-            case FishingMode.PrepareFishing:
+            case FishingOperations.PrepareFishing:
                 HandlePrepareFishing(session, packet);
                 break;
-            case FishingMode.Stop:
+            case FishingOperations.Stop:
                 HandleStop(session);
                 break;
-            case FishingMode.Catch:
+            case FishingOperations.Catch:
                 HandleCatch(session, packet);
                 break;
-            case FishingMode.Start:
+            case FishingOperations.Start:
                 HandleStart(session, packet);
                 break;
-            case FishingMode.FailMinigame:
+            case FishingOperations.FailMinigame:
                 HandleFailMinigame();
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }
@@ -68,13 +68,13 @@ public class FishingHandler : GamePacketHandler
 
         if (!FishingSpotMetadataStorage.CanFish(session.Player.MapId, masteryExp.CurrentExp))
         {
-            session.Send(FishingPacket.Notice((short) FishingNotice.MasteryTooLowForMap));
+            session.Send(FishingPacket.Notice((short) FishingNotices.MasteryTooLowForMap));
             return;
         }
 
         if (!session.Player.Inventory.Items.ContainsKey(fishingRodUid))
         {
-            session.Send(FishingPacket.Notice((short) FishingNotice.InvalidFishingRod));
+            session.Send(FishingPacket.Notice((short) FishingNotices.InvalidFishingRod));
             return;
         }
 
@@ -83,7 +83,7 @@ public class FishingHandler : GamePacketHandler
 
         if (rodMetadata.MasteryLimit < masteryExp.CurrentExp)
         {
-            session.Send(FishingPacket.Notice((short) FishingNotice.MasteryTooLowForRod));
+            session.Send(FishingPacket.Notice((short) FishingNotices.MasteryTooLowForRod));
         }
 
         int direction = Direction.GetClosestDirection(session.Player.FieldPlayer.Rotation);
@@ -92,7 +92,7 @@ public class FishingHandler : GamePacketHandler
         List<MapBlock> fishingBlocks = CollectFishingBlocks(startCoord, direction, session.Player.MapId);
         if (fishingBlocks.Count == 0)
         {
-            session.Send(FishingPacket.Notice((short) FishingNotice.CanOnlyFishNearWater));
+            session.Send(FishingPacket.Notice((short) FishingNotices.CanOnlyFishNearWater));
             return;
         }
         session.Player.FishingRod = fishingRod;

--- a/MapleServer2/PacketHandlers/Game/FunctionCubeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FunctionCubeHandler.cs
@@ -10,25 +10,25 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class FunctionCubeHandler : GamePacketHandler
+internal sealed class FunctionCubeHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.FUNCTION_CUBE;
 
-    private static class FunctionCubeMode
+    private static class FunctionCubeOperations
     {
         public const byte Use = 0x04;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
-        switch (mode)
+        var operation = packet.ReadByte();
+        switch (operation)
         {
-            case FunctionCubeMode.Use:
+            case FunctionCubeOperations.Use:
                 HandleUseCube(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/FunctionCubeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FunctionCubeHandler.cs
@@ -14,21 +14,21 @@ public class FunctionCubeHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.FUNCTION_CUBE;
 
-    private enum FunctionCubeMode : byte
+    private static class FunctionCubeMode
     {
-        Use = 0x04
+        public const byte Use = 0x04;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        FunctionCubeMode mode = (FunctionCubeMode) packet.ReadByte();
+        var mode = packet.ReadByte();
         switch (mode)
         {
             case FunctionCubeMode.Use:
                 HandleUseCube(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/GamePacketHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GamePacketHandler.cs
@@ -5,7 +5,7 @@ using NLog;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public abstract class GamePacketHandler : IPacketHandler<GameSession>
+internal abstract class GamePacketHandler : IPacketHandler<GameSession>
 {
     public abstract RecvOp OpCode { get; }
 

--- a/MapleServer2/PacketHandlers/Game/GlobalPortalHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GlobalPortalHandler.cs
@@ -7,7 +7,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class GlobalPortalHandler : GamePacketHandler
+internal sealed class GlobalPortalHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.GLOBAL_PORTAL;
 

--- a/MapleServer2/PacketHandlers/Game/GlobalPortalHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GlobalPortalHandler.cs
@@ -11,22 +11,22 @@ public class GlobalPortalHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.GLOBAL_PORTAL;
 
-    private enum GlobalPortalMode : byte
+    private static class GlobalPortalOperations
     {
-        Enter = 0x2
+        public const byte Enter = 0x2;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        GlobalPortalMode mode = (GlobalPortalMode) packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
-            case GlobalPortalMode.Enter:
+            case GlobalPortalOperations.Enter:
                 HandleEnter(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/GroupChatHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GroupChatHandler.cs
@@ -6,11 +6,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class GroupChatHandler : GamePacketHandler
+internal sealed class GroupChatHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.GROUP_CHAT;
 
-    private static class GroupChatMode
+    private static class GroupChatOperations
     {
         public const byte Create = 0x1;
         public const byte Invite = 0x2;
@@ -20,24 +20,24 @@ public class GroupChatHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
-            case GroupChatMode.Create:
+            case GroupChatOperations.Create:
                 HandleCreate(session);
                 break;
-            case GroupChatMode.Invite:
+            case GroupChatOperations.Invite:
                 HandleInvite(session, packet);
                 break;
-            case GroupChatMode.Leave:
+            case GroupChatOperations.Leave:
                 HandleLeave(session, packet);
                 break;
-            case GroupChatMode.Chat:
+            case GroupChatOperations.Chat:
                 HandleChat(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/GroupChatHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GroupChatHandler.cs
@@ -10,17 +10,17 @@ public class GroupChatHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.GROUP_CHAT;
 
-    private enum GroupChatMode : byte
+    private static class GroupChatMode
     {
-        Create = 0x1,
-        Invite = 0x2,
-        Leave = 0x4,
-        Chat = 0x0A
+        public const byte Create = 0x1;
+        public const byte Invite = 0x2;
+        public const byte Leave = 0x4;
+        public const byte Chat = 0x0A;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        GroupChatMode mode = (GroupChatMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
@@ -37,7 +37,7 @@ public class GroupChatHandler : GamePacketHandler
                 HandleChat(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/GuideObjectSyncHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GuideObjectSyncHandler.cs
@@ -6,7 +6,7 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class GuideObjectSync : GamePacketHandler
+internal sealed class GuideObjectSync : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.GUIDE_OBJECT_SYNC;
 

--- a/MapleServer2/PacketHandlers/Game/GuildHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GuildHandler.cs
@@ -9,7 +9,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class GuildHandler : GamePacketHandler
+internal sealed class GuildHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.GUILD;
 

--- a/MapleServer2/PacketHandlers/Game/GuildHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GuildHandler.cs
@@ -164,7 +164,7 @@ public class GuildHandler : GamePacketHandler
                 HandleServices(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(typeof(GuildHandler), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/GuildHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/GuildHandler.cs
@@ -13,157 +13,158 @@ public class GuildHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.GUILD;
 
-    private enum GuildMode : byte
+    private static class GuildOperations
     {
-        Create = 0x1,
-        Disband = 0x2,
-        Invite = 0x3,
-        InviteResponse = 0x5,
-        Leave = 0x7,
-        Kick = 0x8,
-        RankChange = 0xA,
-        PlayerMessage = 0xD,
-        CheckIn = 0xF,
-        TransferLeader = 0x3D,
-        GuildNotice = 0x3E,
-        UpdateRank = 0x41,
-        ListGuild = 0x42,
-        SubmitApplication = 0x50,
-        WithdrawApplication = 0x51,
-        ApplicationResponse = 0x52,
-        LoadApplications = 0x54,
-        LoadGuildList = 0x55,
-        SearchGuildByName = 0x56,
-        UseBuff = 0x59,
-        UpgradeBuff = 0x5A,
-        UpgradeHome = 0x62,
-        ChangeHomeTheme = 0x63,
-        EnterHouse = 0x64,
-        GuildDonate = 0x6E,
-        Services = 0x6F
+        public const byte Create = 0x1;
+        public const byte Disband = 0x2;
+        public const byte Invite = 0x3;
+        public const byte InviteResponse = 0x5;
+        public const byte Leave = 0x7;
+        public const byte Kick = 0x8;
+        public const byte RankChange = 0xA;
+        public const byte PlayerMessage = 0xD;
+        public const byte CheckIn = 0xF;
+        public const byte TransferLeader = 0x3D;
+        public const byte GuildNotice = 0x3E;
+        public const byte UpdateRank = 0x41;
+        public const byte ListGuild = 0x42;
+        public const byte SubmitApplication = 0x50;
+        public const byte WithdrawApplication = 0x51;
+        public const byte ApplicationResponse = 0x52;
+        public const byte LoadApplications = 0x54;
+        public const byte LoadGuildList = 0x55;
+        public const byte SearchGuildByName = 0x56;
+        public const byte UseBuff = 0x59;
+        public const byte UpgradeBuff = 0x5A;
+        public const byte UpgradeHome = 0x62;
+        public const byte ChangeHomeTheme = 0x63;
+        public const byte EnterHouse = 0x64;
+        public const byte GuildDonate = 0x6E;
+        public const byte Services = 0x6F;
     }
 
-    private enum GuildErrorNotice : byte
+    private static class GuildErrorNotice
     {
-        GuildNotFound = 0x3,
-        CharacterIsAlreadyInAGuild = 0x4,
-        UnableToSendInvite = 0x5,
-        InviteFailed = 0x6,
-        UserAlreadyJoinedAGuild = 0x7,
-        GuildNoLongerValid = 0x8,
-        UnableToInvitePlayer = 0xA,
-        GuildWithSameNameExists = 0xB,
-        NameContainsForbiddenWord = 0xC,
-        GuildMemberNotFound = 0xD,
-        CannotDisbandWithMembers = 0xE,
-        GuildIsAtCapacity = 0xF,
-        GuildMemberHasNotJoined = 0x10,
-        LeaderCannotLeaveGuild = 0x11,
-        CannotKickLeader = 0x12,
-        NotEnoughMesos = 0x14,
-        InsufficientPermissions = 0x15,
-        OnlyLeaderCanDoThis = 0x16,
-        RankCannotBeUsed = 0x17,
-        CannotChangeMaxCapacityToValue = 0x18,
-        IncorrectRank = 0x19,
-        RankCannotBeGranted = 0x1B,
-        RankSettingFailed = 0x1C,
-        CannotDoDuringGuildBattle = 0x21,
-        ApplicationNotFound = 0x27,
-        TargetIsInAnUninvitableLocation = 0x29,
-        GuildLevelNotHighEnough = 0x2A,
-        InsufficientGuildFunds = 0x2B,
-        CannotUseGuildSkillsRightNow = 0x2C,
-        YouAreAlreadyAtGloriousArena = 0x2E,
-        ApplicationsAreNotAccepted = 0x2F,
-        YouNeedAtLeastXPlayersOnline = 0x30
+        public const byte GuildNotFound = 0x3;
+        public const byte CharacterIsAlreadyInAGuild = 0x4;
+        public const byte UnableToSendInvite = 0x5;
+        public const byte InviteFailed = 0x6;
+        public const byte UserAlreadyJoinedAGuild = 0x7;
+        public const byte GuildNoLongerValid = 0x8;
+        public const byte UnableToInvitePlayer = 0xA;
+        public const byte GuildWithSameNameExists = 0xB;
+        public const byte NameContainsForbiddenWord = 0xC;
+        public const byte GuildMemberNotFound = 0xD;
+        public const byte CannotDisbandWithMembers = 0xE;
+        public const byte GuildIsAtCapacity = 0xF;
+        public const byte GuildMemberHasNotJoined = 0x10;
+        public const byte LeaderCannotLeaveGuild = 0x11;
+        public const byte CannotKickLeader = 0x12;
+        public const byte NotEnoughMesos = 0x14;
+        public const byte InsufficientPermissions = 0x15;
+        public const byte OnlyLeaderCanDoThis = 0x16;
+        public const byte RankCannotBeUsed = 0x17;
+        public const byte CannotChangeMaxCapacityToValue = 0x18;
+        public const byte IncorrectRank = 0x19;
+        public const byte RankCannotBeGranted = 0x1B;
+        public const byte RankSettingFailed = 0x1C;
+        public const byte CannotDoDuringGuildBattle = 0x21;
+        public const byte ApplicationNotFound = 0x27;
+        public const byte TargetIsInAnUninvitableLocation = 0x29;
+        public const byte GuildLevelNotHighEnough = 0x2A;
+        public const byte InsufficientGuildFunds = 0x2B;
+        public const byte CannotUseGuildSkillsRightNow = 0x2C;
+        public const byte YouAreAlreadyAtGloriousArena = 0x2E;
+        public const byte ApplicationsAreNotAccepted = 0x2F;
+        public const byte YouNeedAtLeastXPlayersOnline = 0x30;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        GuildMode mode = (GuildMode) packet.ReadByte();
+        byte mode = packet.ReadByte();
+
         switch (mode)
         {
-            case GuildMode.Create:
+            case GuildOperations.Create:
                 HandleCreate(session, packet);
                 break;
-            case GuildMode.Disband:
+            case GuildOperations.Disband:
                 HandleDisband(session);
                 break;
-            case GuildMode.Invite:
+            case GuildOperations.Invite:
                 HandleInvite(session, packet);
                 break;
-            case GuildMode.InviteResponse:
+            case GuildOperations.InviteResponse:
                 HandleInviteResponse(session, packet);
                 break;
-            case GuildMode.Leave:
+            case GuildOperations.Leave:
                 HandleLeave(session);
                 break;
-            case GuildMode.Kick:
+            case GuildOperations.Kick:
                 HandleKick(session, packet);
                 break;
-            case GuildMode.RankChange:
+            case GuildOperations.RankChange:
                 HandleRankChange(session, packet);
                 break;
-            case GuildMode.PlayerMessage:
+            case GuildOperations.PlayerMessage:
                 HandlePlayerMessage(session, packet);
                 break;
-            case GuildMode.CheckIn:
+            case GuildOperations.CheckIn:
                 HandleCheckIn(session);
                 break;
-            case GuildMode.TransferLeader:
+            case GuildOperations.TransferLeader:
                 HandleTransferLeader(session, packet);
                 break;
-            case GuildMode.GuildNotice:
+            case GuildOperations.GuildNotice:
                 HandleGuildNotice(session, packet);
                 break;
-            case GuildMode.UpdateRank:
+            case GuildOperations.UpdateRank:
                 HandleUpdateRank(session, packet);
                 break;
-            case GuildMode.ListGuild:
+            case GuildOperations.ListGuild:
                 HandleListGuild(session, packet);
                 break;
-            case GuildMode.SubmitApplication:
+            case GuildOperations.SubmitApplication:
                 HandleSubmitApplication(session, packet);
                 break;
-            case GuildMode.WithdrawApplication:
+            case GuildOperations.WithdrawApplication:
                 HandleWithdrawApplication(session, packet);
                 break;
-            case GuildMode.ApplicationResponse:
+            case GuildOperations.ApplicationResponse:
                 HandleApplicationResponse(session, packet);
                 break;
-            case GuildMode.LoadApplications:
+            case GuildOperations.LoadApplications:
                 HandleLoadApplications(session);
                 break;
-            case GuildMode.LoadGuildList:
+            case GuildOperations.LoadGuildList:
                 HandleLoadGuildList(session, packet);
                 break;
-            case GuildMode.SearchGuildByName:
+            case GuildOperations.SearchGuildByName:
                 HandleSearchGuildByName(session, packet);
                 break;
-            case GuildMode.UseBuff:
+            case GuildOperations.UseBuff:
                 HandleUseBuff(session, packet);
                 break;
-            case GuildMode.UpgradeBuff:
+            case GuildOperations.UpgradeBuff:
                 HandleUpgradeBuff(session, packet);
                 break;
-            case GuildMode.UpgradeHome:
+            case GuildOperations.UpgradeHome:
                 HandleUpgradeHome(session, packet);
                 break;
-            case GuildMode.ChangeHomeTheme:
+            case GuildOperations.ChangeHomeTheme:
                 HandleChangeHomeTheme(session, packet);
                 break;
-            case GuildMode.EnterHouse:
+            case GuildOperations.EnterHouse:
                 HandleEnterHouse(session);
                 break;
-            case GuildMode.GuildDonate:
+            case GuildOperations.GuildDonate:
                 HandleGuildDonate(session, packet);
                 break;
-            case GuildMode.Services:
+            case GuildOperations.Services:
                 HandleServices(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(typeof(GuildHandler), mode);
                 break;
         }
     }
@@ -179,13 +180,13 @@ public class GuildHandler : GamePacketHandler
 
         if (!session.Player.Wallet.Meso.Modify(-2000))
         {
-            session.Send(GuildPacket.ErrorNotice((byte) GuildErrorNotice.NotEnoughMesos));
+            session.Send(GuildPacket.ErrorNotice(GuildErrorNotice.NotEnoughMesos));
             return;
         }
 
         if (DatabaseManager.Guilds.NameExists(guildName))
         {
-            session.Send(GuildPacket.ErrorNotice((byte) GuildErrorNotice.GuildWithSameNameExists));
+            session.Send(GuildPacket.ErrorNotice(GuildErrorNotice.GuildWithSameNameExists));
             return;
         }
         Guild newGuild = new(guildName, session.Player);
@@ -253,12 +254,12 @@ public class GuildHandler : GamePacketHandler
         Player playerInvited = GameServer.PlayerManager.GetPlayerByName(targetPlayer);
         if (playerInvited == null)
         {
-            session.Send(GuildPacket.ErrorNotice((byte) GuildErrorNotice.UnableToSendInvite));
+            session.Send(GuildPacket.ErrorNotice(GuildErrorNotice.UnableToSendInvite));
         }
 
         if (playerInvited.Guild != null)
         {
-            session.Send(GuildPacket.ErrorNotice((byte) GuildErrorNotice.CharacterIsAlreadyInAGuild));
+            session.Send(GuildPacket.ErrorNotice(GuildErrorNotice.CharacterIsAlreadyInAGuild));
             return;
         }
 
@@ -850,7 +851,7 @@ public class GuildHandler : GamePacketHandler
 
         if (!session.Player.Wallet.Meso.Modify(-donationAmount))
         {
-            session.Send(GuildPacket.ErrorNotice((byte) GuildErrorNotice.NotEnoughMesos));
+            session.Send(GuildPacket.ErrorNotice(GuildErrorNotice.NotEnoughMesos));
             return;
         }
 

--- a/MapleServer2/PacketHandlers/Game/Helpers/GatheringHelper.cs
+++ b/MapleServer2/PacketHandlers/Game/Helpers/GatheringHelper.cs
@@ -6,7 +6,7 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game.Helpers;
 
-public static class GatheringHelper
+internal static class GatheringHelper
 {
     public static void HandleGathering(GameSession session, int recipeId, out int numDrop)
     {

--- a/MapleServer2/PacketHandlers/Game/Helpers/ItemBoxHelper.cs
+++ b/MapleServer2/PacketHandlers/Game/Helpers/ItemBoxHelper.cs
@@ -9,7 +9,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game.Helpers;
 
-public static class ItemBoxHelper
+internal static class ItemBoxHelper
 {
     public static List<Item> GetItemsFromDropGroup(DropGroupContent dropContent, Gender playerGender, Job job)
     {

--- a/MapleServer2/PacketHandlers/Game/Helpers/JobHelper.cs
+++ b/MapleServer2/PacketHandlers/Game/Helpers/JobHelper.cs
@@ -2,7 +2,7 @@
 
 namespace MapleServer2.PacketHandlers.Game.Helpers;
 
-public static class JobHelper
+internal static class JobHelper
 {
     public static bool CheckJobFlagForJob(List<Job> jobs, JobFlag jobFlag)
     {

--- a/MapleServer2/PacketHandlers/Game/Helpers/MailHelper.cs
+++ b/MapleServer2/PacketHandlers/Game/Helpers/MailHelper.cs
@@ -5,7 +5,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game.Helpers;
 
-public class MailHelper
+internal static class MailHelper
 {
     public static void SendMail(MailType type, long recipientCharacterId, long senderCharacterId, string senderName, string title, string body, string addParameter1, string addParameter2, List<Item> items, long mesos, long merets, out Mail mail)
     {

--- a/MapleServer2/PacketHandlers/Game/Helpers/QuestHelper.cs
+++ b/MapleServer2/PacketHandlers/Game/Helpers/QuestHelper.cs
@@ -8,7 +8,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game.Helpers;
 
-public static class QuestHelper
+internal static class QuestHelper
 {
     public static void UpdateExplorationQuest(GameSession session, string code, string type)
     {

--- a/MapleServer2/PacketHandlers/Game/HomeActionHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/HomeActionHandler.cs
@@ -15,39 +15,39 @@ public class HomeActionHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.HOME_ACTION;
 
-    private enum HomeActionMode : byte
+    private static class HomeActionOperations
     {
-        Smite = 0x01,
-        Kick = 0x02,
-        Survey = 0x05,
-        ChangePortalSettings = 0x06,
-        UpdateBallCoord = 0x07,
-        SendPortalSettings = 0x0D
+        public const byte Smite = 0x01;
+        public const byte Kick = 0x02;
+        public const byte Survey = 0x05;
+        public const byte ChangePortalSettings = 0x06;
+        public const byte UpdateBallCoord = 0x07;
+        public const byte SendPortalSettings = 0x0D;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        HomeActionMode mode = (HomeActionMode) packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
-            case HomeActionMode.Kick:
+            case HomeActionOperations.Kick:
                 HandleKick(packet);
                 break;
-            case HomeActionMode.Survey:
+            case HomeActionOperations.Survey:
                 HandleRespondSurvey(session, packet);
                 break;
-            case HomeActionMode.ChangePortalSettings:
+            case HomeActionOperations.ChangePortalSettings:
                 HandleChangePortalSettings(session, packet);
                 break;
-            case HomeActionMode.UpdateBallCoord:
+            case HomeActionOperations.UpdateBallCoord:
                 HandleUpdateBallCoord(session, packet);
                 break;
-            case HomeActionMode.SendPortalSettings:
+            case HomeActionOperations.SendPortalSettings:
                 HandleSendPortalSettings(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/HomeActionHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/HomeActionHandler.cs
@@ -11,7 +11,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class HomeActionHandler : GamePacketHandler
+internal sealed class HomeActionHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.HOME_ACTION;
 

--- a/MapleServer2/PacketHandlers/Game/InsigniaHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/InsigniaHandler.cs
@@ -6,13 +6,12 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class InsigniaHandler : GamePacketHandler
+internal sealed class InsigniaHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.INSIGNIA;
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-
         short insigniaId = packet.ReadShort();
 
         if (insigniaId < 0 && !InsigniaMetadataStorage.IsValid(insigniaId))

--- a/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
@@ -9,7 +9,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class InstrumentHandler : GamePacketHandler
+internal sealed class InstrumentHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.PLAY_INSTRUMENT;
 

--- a/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/InstrumentHandler.cs
@@ -13,58 +13,58 @@ public class InstrumentHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.PLAY_INSTRUMENT;
 
-    private enum InstrumentMode : byte
+    private static class InstrumentOperation
     {
-        StartImprovise = 0x0,
-        PlayNote = 0x1,
-        StopImprovise = 0x2,
-        PlayScore = 0x3,
-        StopScore = 0x4,
-        StartEnsemble = 0x5,
-        LeaveEnsemble = 0x6,
-        Compose = 0x8,
-        Fireworks = 0xE,
-        AudienceEmote = 0xF
+        public const byte StartImprovise = 0x0;
+        public const byte PlayNote = 0x1;
+        public const byte StopImprovise = 0x2;
+        public const byte PlayScore = 0x3;
+        public const byte StopScore = 0x4;
+        public const byte StartEnsemble = 0x5;
+        public const byte LeaveEnsemble = 0x6;
+        public const byte Compose = 0x8;
+        public const byte Fireworks = 0xE;
+        public const byte AudienceEmote = 0xF;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        InstrumentMode mode = (InstrumentMode) packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
-            case InstrumentMode.StartImprovise:
+            case InstrumentOperation.StartImprovise:
                 HandleStartImprovise(session, packet);
                 break;
-            case InstrumentMode.PlayNote:
+            case InstrumentOperation.PlayNote:
                 HandlePlayNote(session, packet);
                 break;
-            case InstrumentMode.StopImprovise:
+            case InstrumentOperation.StopImprovise:
                 HandleStopImprovise(session);
                 break;
-            case InstrumentMode.PlayScore:
+            case InstrumentOperation.PlayScore:
                 HandlePlayScore(session, packet);
                 break;
-            case InstrumentMode.StopScore:
+            case InstrumentOperation.StopScore:
                 HandleStopScore(session);
                 break;
-            case InstrumentMode.StartEnsemble:
+            case InstrumentOperation.StartEnsemble:
                 HandleStartEnsemble(session, packet);
                 break;
-            case InstrumentMode.LeaveEnsemble:
+            case InstrumentOperation.LeaveEnsemble:
                 HandleLeaveEnsemble(session);
                 break;
-            case InstrumentMode.Compose:
+            case InstrumentOperation.Compose:
                 HandleCompose(session, packet);
                 break;
-            case InstrumentMode.Fireworks:
+            case InstrumentOperation.Fireworks:
                 HandleFireworks(session);
                 break;
-            case InstrumentMode.AudienceEmote:
+            case InstrumentOperation.AudienceEmote:
                 HandleAudienceEmote(packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/InteractObjectHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/InteractObjectHandler.cs
@@ -15,15 +15,15 @@ internal class InteractObjectHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.INTERACT_OBJECT;
 
-    private enum InteractObjectMode : byte
+    private static class InteractObjectMode
     {
-        Cast = 0x0B,
-        Interact = 0x0C
+        public const byte Cast = 0x0B;
+        public const byte Interact = 0x0C;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        InteractObjectMode mode = (InteractObjectMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {

--- a/MapleServer2/PacketHandlers/Game/InteractObjectHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/InteractObjectHandler.cs
@@ -11,7 +11,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-internal class InteractObjectHandler : GamePacketHandler
+internal sealed class InteractObjectHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.INTERACT_OBJECT;
 

--- a/MapleServer2/PacketHandlers/Game/ItemEnchantHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemEnchantHandler.cs
@@ -12,9 +12,9 @@ public class ItemEnchantHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        byte function = packet.ReadByte();
+        byte operation = packet.ReadByte();
 
-        switch (function)
+        switch (operation)
         {
             case 0: // Sent when opening up enchant ui
                 break;

--- a/MapleServer2/PacketHandlers/Game/ItemEnchantHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemEnchantHandler.cs
@@ -6,7 +6,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class ItemEnchantHandler : GamePacketHandler
+internal sealed class ItemEnchantHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_ITEM_ENCHANT;
 

--- a/MapleServer2/PacketHandlers/Game/ItemEquipHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemEquipHandler.cs
@@ -11,22 +11,22 @@ public class ItemEquipHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.ITEM_EQUIP;
 
-    private enum ItemEquipMode : byte
+    private class ItemEquipOperations
     {
-        Equip = 0,
-        Unequip = 1
+        public const byte Equip = 0;
+        public const byte Unequip = 1;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ItemEquipMode function = (ItemEquipMode) packet.ReadByte();
+        var function = packet.ReadByte();
 
         switch (function)
         {
-            case ItemEquipMode.Equip:
+            case ItemEquipOperations.Equip:
                 HandleEquipItem(session, packet);
                 break;
-            case ItemEquipMode.Unequip:
+            case ItemEquipOperations.Unequip:
                 HandleUnequipItem(session, packet);
                 break;
         }

--- a/MapleServer2/PacketHandlers/Game/ItemEquipHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemEquipHandler.cs
@@ -7,11 +7,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class ItemEquipHandler : GamePacketHandler
+internal sealed class ItemEquipHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.ITEM_EQUIP;
 
-    private class ItemEquipOperations
+    private static class ItemEquipOperations
     {
         public const byte Equip = 0;
         public const byte Unequip = 1;
@@ -19,9 +19,9 @@ public class ItemEquipHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var function = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (function)
+        switch (operation)
         {
             case ItemEquipOperations.Equip:
                 HandleEquipItem(session, packet);

--- a/MapleServer2/PacketHandlers/Game/ItemExchangeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemExchangeHandler.cs
@@ -8,13 +8,25 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class ItemExchangeHandler : GamePacketHandler
+internal sealed class ItemExchangeHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.ITEM_EXCHANGE;
 
-    private class ItemExchangeOperations
+    private static class ItemExchangeOperations
     {
         public const byte Use = 0x1;
+    }
+    
+    private static class ItemExchangeNotices
+    {
+        public const short Sucess = 0x0;
+        public const short Invalid = 0x1;
+        public const short CannotFuse = 0x2;
+        public const short InsufficientMeso = 0x3;
+        public const short InsufficientItems = 0x4;
+        public const short EnchantLevelTooHigh = 0x5;
+        public const short ItemIsLocked = 0x6;
+        public const short CheckFusionAmount = 0x7;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
@@ -30,18 +42,6 @@ public class ItemExchangeHandler : GamePacketHandler
                 IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
-    }
-
-    public enum ExchangeNotice : short
-    {
-        Sucess = 0x0,
-        Invalid = 0x1,
-        CannotFuse = 0x2,
-        InsufficientMeso = 0x3,
-        InsufficientItems = 0x4,
-        EnchantLevelTooHigh = 0x5,
-        ItemIsLocked = 0x6,
-        CheckFusionAmount = 0x7
     }
 
     private static void HandleUse(GameSession session, PacketReader packet)
@@ -61,13 +61,13 @@ public class ItemExchangeHandler : GamePacketHandler
 
         if (!session.Player.Wallet.Meso.Modify(-exchange.MesoCost * quantity))
         {
-            session.Send(ItemExchangePacket.Notice((short) ExchangeNotice.InsufficientMeso));
+            session.Send(ItemExchangePacket.Notice(ItemExchangeNotices.InsufficientMeso));
             return;
         }
 
         if (exchange.ItemCost.Count != 0 && !PlayerHasAllIngredients(session, exchange, quantity))
         {
-            session.Send(ItemExchangePacket.Notice((short) ExchangeNotice.InsufficientItems));
+            session.Send(ItemExchangePacket.Notice(ItemExchangeNotices.InsufficientItems));
             return;
         }
 
@@ -83,7 +83,7 @@ public class ItemExchangeHandler : GamePacketHandler
         };
 
         session.Player.Inventory.AddItem(session, exchangeRewardItem, true);
-        session.Send(ItemExchangePacket.Notice((short) ExchangeNotice.Sucess));
+        session.Send(ItemExchangePacket.Notice(ItemExchangeNotices.Sucess));
 
     }
 

--- a/MapleServer2/PacketHandlers/Game/ItemExchangeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemExchangeHandler.cs
@@ -12,22 +12,22 @@ public class ItemExchangeHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.ITEM_EXCHANGE;
 
-    private enum ItemExchangeMode : byte
+    private class ItemExchangeOperations
     {
-        Use = 0x1
+        public const byte Use = 0x1;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ItemExchangeMode mode = (ItemExchangeMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
-            case ItemExchangeMode.Use:
+            case ItemExchangeOperations.Use:
                 HandleUse(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/ItemExtractionHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemExtractionHandler.cs
@@ -8,7 +8,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class ItemExtractionHandler : GamePacketHandler
+internal sealed class ItemExtractionHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.ITEM_EXTRACTION;
 

--- a/MapleServer2/PacketHandlers/Game/ItemRepackageHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemRepackageHandler.cs
@@ -11,31 +11,31 @@ public class ItemRepackageHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.ITEM_REPACKAGE;
 
-    private enum ItemRepackageMode : byte
+    private static class ItemRepackageOperations
     {
-        Repackage = 0x1
+        public const byte Repackage = 0x1;
     }
 
-    private enum ItemRepackageNotice
+    private static class ItemRepackageErrors
     {
-        CannotBePackaged = 0x1,
-        ItemInvalid = 0x2,
-        CannotRepackageRightNow = 0x3,
-        InvalidRarity = 0x4,
-        InvalidLevel = 0x5
+        public const byte CannotBePackaged = 0x1;
+        public const byte ItemInvalid = 0x2;
+        public const byte CannotRepackageRightNow = 0x3;
+        public const byte InvalidRarity = 0x4;
+        public const byte InvalidLevel = 0x5;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ItemRepackageMode mode = (ItemRepackageMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
-            case ItemRepackageMode.Repackage:
+            case ItemRepackageOperations.Repackage:
                 HandleRepackage(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }
@@ -49,25 +49,25 @@ public class ItemRepackageHandler : GamePacketHandler
         Item repackingItem = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Uid == repackingItemUid);
         if (repackingItem == null || ribbon == null)
         {
-            session.Send(ItemRepackagePacket.Notice((int) ItemRepackageNotice.ItemInvalid));
+            session.Send(ItemRepackagePacket.Notice(ItemRepackageErrors.ItemInvalid));
             return;
         }
 
         if (repackingItem.RemainingTrades != 0)
         {
-            session.Send(ItemRepackagePacket.Notice((int) ItemRepackageNotice.CannotBePackaged));
+            session.Send(ItemRepackagePacket.Notice(ItemRepackageErrors.CannotBePackaged));
         }
 
         int ribbonRequirementAmount = ItemMetadataStorage.GetRepackageConsumeCount(ribbon.Id);
         if (ribbonRequirementAmount > ribbon.Amount)
         {
-            session.Send(ItemRepackagePacket.Notice((int) ItemRepackageNotice.CannotBePackaged));
+            session.Send(ItemRepackagePacket.Notice(ItemRepackageErrors.CannotBePackaged));
             return;
         }
 
         if (!ItemRepackageMetadataStorage.ItemCanRepackage(ribbon.Function.Id, repackingItem.Level, repackingItem.Rarity))
         {
-            session.Send(ItemRepackagePacket.Notice((int) ItemRepackageNotice.ItemInvalid));
+            session.Send(ItemRepackagePacket.Notice(ItemRepackageErrors.ItemInvalid));
             return;
         }
 

--- a/MapleServer2/PacketHandlers/Game/ItemRepackageHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemRepackageHandler.cs
@@ -7,7 +7,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class ItemRepackageHandler : GamePacketHandler
+internal sealed class ItemRepackageHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.ITEM_REPACKAGE;
 
@@ -27,15 +27,15 @@ public class ItemRepackageHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
             case ItemRepackageOperations.Repackage:
                 HandleRepackage(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/ItemSocketSystemHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemSocketSystemHandler.cs
@@ -8,7 +8,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class ItemSocketSystemHandler : GamePacketHandler
+internal sealed class ItemSocketSystemHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.ITEM_SOCKET_SYSTEM;
 
@@ -22,7 +22,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
         public const byte ExtractGem = 0xA;
     }
 
-    private static class ItemSocketSystemNotice
+    private static class ItemSocketSystemNotices
     {
         public const byte TargetIsNotInYourInventory = 0x1;
         public const byte ItemIsNotInYourInventory = 0x2;
@@ -74,7 +74,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
         Inventory inventory = session.Player.Inventory;
         if (!inventory.Items.ContainsKey(itemUid))
         {
-            session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
+            session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotices.ItemIsNotInYourInventory));
             return;
         }
         Item equip = inventory.Items[itemUid];
@@ -84,7 +84,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
         {
             if (!inventory.Items.ContainsKey(uid))
             {
-                session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
+                session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotices.ItemIsNotInYourInventory));
                 return;
             }
 
@@ -92,7 +92,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
             int fodderUnlockedSlotCount = fodder.Stats.GemSockets.Where(x => x.IsUnlocked).Count();
             if (equipUnlockedSlotCount != fodderUnlockedSlotCount)
             {
-                session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.CannotBeUsedAsMaterial));
+                session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotices.CannotBeUsedAsMaterial));
                 return;
             }
         }
@@ -154,7 +154,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
 
         if (!session.Player.Inventory.Items.ContainsKey(itemUid))
         {
-            session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
+            session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotices.ItemIsNotInYourInventory));
             return;
         }
 
@@ -174,7 +174,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
         {
             if (!inventory.Items.ContainsKey(itemUid))
             {
-                session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
+                session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotices.ItemIsNotInYourInventory));
                 return;
             }
 
@@ -210,7 +210,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
         // upgrade gem mounted on a equipment
         if (!inventory.Items.ContainsKey(equipUid))
         {
-            session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
+            session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotices.ItemIsNotInYourInventory));
             return;
         }
 
@@ -307,7 +307,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
         {
             if (!session.Player.Inventory.Items.ContainsKey(itemUid))
             {
-                session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
+                session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotices.ItemIsNotInYourInventory));
                 return;
             }
 
@@ -318,7 +318,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
         // select gem mounted on a equipment
         if (!session.Player.Inventory.Items.ContainsKey(equipUid))
         {
-            session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
+            session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotices.ItemIsNotInYourInventory));
             return;
         }
 
@@ -339,13 +339,13 @@ public class ItemSocketSystemHandler : GamePacketHandler
 
         if (!session.Player.Inventory.Items.ContainsKey(equipItemUid))
         {
-            session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.TargetIsNotInYourInventory));
+            session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotices.TargetIsNotInYourInventory));
             return;
         }
 
         if (!session.Player.Inventory.Items.ContainsKey(gemItemUid))
         {
-            session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
+            session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotices.ItemIsNotInYourInventory));
             return;
         }
 
@@ -387,7 +387,7 @@ public class ItemSocketSystemHandler : GamePacketHandler
 
         if (!session.Player.Inventory.Items.ContainsKey(equipItemUid))
         {
-            session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotice.ItemIsNotInYourInventory));
+            session.Send(ItemSocketSystemPacket.Notice((int) ItemSocketSystemNotices.ItemIsNotInYourInventory));
             return;
         }
 

--- a/MapleServer2/PacketHandlers/Game/ItemSocketSystemHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemSocketSystemHandler.cs
@@ -12,50 +12,50 @@ public class ItemSocketSystemHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.ITEM_SOCKET_SYSTEM;
 
-    private enum ItemSocketSystemMode : byte
+    private static class ItemSocketSystemOperations
     {
-        UnlockSocket = 0x0,
-        SelectUnlockSocketEquip = 0x2,
-        UpgradeGem = 0x4,
-        SelectGemUpgrade = 0x6,
-        MountGem = 0x8,
-        ExtractGem = 0xA
+        public const byte UnlockSocket = 0x0;
+        public const byte SelectUnlockSocketEquip = 0x2;
+        public const byte UpgradeGem = 0x4;
+        public const byte SelectGemUpgrade = 0x6;
+        public const byte MountGem = 0x8;
+        public const byte ExtractGem = 0xA;
     }
 
-    private enum ItemSocketSystemNotice
+    private static class ItemSocketSystemNotice
     {
-        TargetIsNotInYourInventory = 0x1,
-        ItemIsNotInYourInventory = 0x2,
-        CannotBeUsedAsMaterial = 0x3,
-        ConfirmCatalystAmount = 0x4
+        public const byte TargetIsNotInYourInventory = 0x1;
+        public const byte ItemIsNotInYourInventory = 0x2;
+        public const byte CannotBeUsedAsMaterial = 0x3;
+        public const byte ConfirmCatalystAmount = 0x4;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ItemSocketSystemMode mode = (ItemSocketSystemMode) packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
-            case ItemSocketSystemMode.UnlockSocket:
+            case ItemSocketSystemOperations.UnlockSocket:
                 HandleUnlockSocket(session, packet);
                 break;
-            case ItemSocketSystemMode.SelectUnlockSocketEquip:
+            case ItemSocketSystemOperations.SelectUnlockSocketEquip:
                 HandleSelectUnlockSocketEquip(session, packet);
                 break;
-            case ItemSocketSystemMode.SelectGemUpgrade:
+            case ItemSocketSystemOperations.SelectGemUpgrade:
                 HandleSelectGemUpgrade(session, packet);
                 break;
-            case ItemSocketSystemMode.UpgradeGem:
+            case ItemSocketSystemOperations.UpgradeGem:
                 HandleUpgradeGem(session, packet);
                 break;
-            case ItemSocketSystemMode.MountGem:
+            case ItemSocketSystemOperations.MountGem:
                 HandleMountGem(session, packet);
                 break;
-            case ItemSocketSystemMode.ExtractGem:
+            case ItemSocketSystemOperations.ExtractGem:
                 HandleExtractGem(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/JobHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/JobHandler.cs
@@ -11,33 +11,33 @@ public class JobHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.JOB;
 
-    private enum JobMode : byte
+    private static class JobOperations
     {
-        Close = 0x08,
-        Save = 0x09,
-        Reset = 0x0A,
-        Preset = 0x0B
+        public const byte Close = 0x08;
+        public const byte Save = 0x09;
+        public const byte Reset = 0x0A;
+        public const byte Preset = 0x0B;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        JobMode mode = (JobMode) packet.ReadByte();
-        switch (mode)
+        var operation = packet.ReadByte();
+        switch (operation)
         {
-            case JobMode.Close:
+            case JobOperations.Close:
                 HandleCloseSkillTree(session);
                 break;
-            case JobMode.Save:
+            case JobOperations.Save:
                 HandleSaveSkillTree(session, packet);
                 break;
-            case JobMode.Reset:
+            case JobOperations.Reset:
                 HandleResetSkillTree(session, packet);
                 break;
-            case JobMode.Preset:
+            case JobOperations.Preset:
                 HandlePresetSkillTree(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/JobHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/JobHandler.cs
@@ -7,7 +7,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class JobHandler : GamePacketHandler
+internal sealed class JobHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.JOB;
 

--- a/MapleServer2/PacketHandlers/Game/KeyTableHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/KeyTableHandler.cs
@@ -10,38 +10,38 @@ public class KeyTableHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.KEY_TABLE;
 
-    private enum KeyTableEnum : byte
+    private static class KeyTableOperations
     {
-        SetKeyBind = 0x02,
-        MoveQuickSlot = 0x03,
-        AddToFirstSlot = 0x04,
-        RemoveQuickSlot = 0x05,
-        SetActiveHotbar = 0x08
+        public const byte SetKeyBind = 0x02;
+        public const byte MoveQuickSlot = 0x03;
+        public const byte AddToFirstSlot = 0x04;
+        public const byte RemoveQuickSlot = 0x05;
+        public const byte SetActiveHotbar = 0x08;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        KeyTableEnum requestType = (KeyTableEnum) packet.ReadByte();
+        var requestType = packet.ReadByte();
 
         switch (requestType)
         {
-            case KeyTableEnum.SetKeyBind:
+            case KeyTableOperations.SetKeyBind:
                 SetKeyBinds(session, packet);
                 break;
-            case KeyTableEnum.MoveQuickSlot:
+            case KeyTableOperations.MoveQuickSlot:
                 MoveQuickSlot(session, packet);
                 break;
-            case KeyTableEnum.AddToFirstSlot:
+            case KeyTableOperations.AddToFirstSlot:
                 AddToQuickSlot(session, packet);
                 break;
-            case KeyTableEnum.RemoveQuickSlot:
+            case KeyTableOperations.RemoveQuickSlot:
                 RemoveQuickSlot(session, packet);
                 break;
-            case KeyTableEnum.SetActiveHotbar:
+            case KeyTableOperations.SetActiveHotbar:
                 SetActiveHotbar(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(requestType);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), requestType);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/KeyTableHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/KeyTableHandler.cs
@@ -6,7 +6,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class KeyTableHandler : GamePacketHandler
+internal sealed class KeyTableHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.KEY_TABLE;
 

--- a/MapleServer2/PacketHandlers/Game/LapenshardHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/LapenshardHandler.cs
@@ -8,7 +8,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class LapenshardHandler : GamePacketHandler
+internal sealed class LapenshardHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.ITEM_LAPENSHARD;
 

--- a/MapleServer2/PacketHandlers/Game/LapenshardHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/LapenshardHandler.cs
@@ -12,44 +12,44 @@ public class LapenshardHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.ITEM_LAPENSHARD;
 
-    private enum LapenshardMode : byte
+    private static class LapenshardOperations
     {
-        Equip = 0x1,
-        Unequip = 0x2,
-        AddFusion = 0x3,
-        AddCatalyst = 0x4,
-        Fusion = 0x5,
+        public const byte Equip = 0x1;
+        public const byte Unequip = 0x2;
+        public const byte AddFusion = 0x3;
+        public const byte AddCatalyst = 0x4;
+        public const byte Fusion = 0x5;
     }
 
-    private enum LapenshardColor : byte
+    private static class LapenshardColor
     {
-        Red = 41,
-        Blue = 42,
-        Green = 43,
+        public const byte Red = 41;
+        public const byte Blue = 42;
+        public const byte Green = 43;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        LapenshardMode mode = (LapenshardMode) packet.ReadByte();
-        switch (mode)
+        var operation = packet.ReadByte();
+        switch (operation)
         {
-            case LapenshardMode.Equip:
+            case LapenshardOperations.Equip:
                 HandleEquip(session, packet);
                 break;
-            case LapenshardMode.Unequip:
+            case LapenshardOperations.Unequip:
                 HandleUnequip(session, packet);
                 break;
-            case LapenshardMode.AddFusion:
+            case LapenshardOperations.AddFusion:
                 HandleAddFusion(session, packet);
                 break;
-            case LapenshardMode.AddCatalyst:
+            case LapenshardOperations.AddCatalyst:
                 HandleAddCatalyst(session, packet);
                 break;
-            case LapenshardMode.Fusion:
+            case LapenshardOperations.Fusion:
                 HandleFusion(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }
@@ -164,7 +164,7 @@ public class LapenshardHandler : GamePacketHandler
             }
         }
 
-        LapenshardColor itemType = (LapenshardColor) (itemId / 1000000);
+        var itemType = itemId / 1000000;
         string crystal = "";
         switch (itemType)
         {

--- a/MapleServer2/PacketHandlers/Game/LiftableHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/LiftableHandler.cs
@@ -9,24 +9,24 @@ namespace MapleServer2.PacketHandlers.Game;
 
 public class LiftableHandler : GamePacketHandler
 {
-    private enum LiftableMode : byte
+    private static class LiftableOperations
     {
-        PickUp = 1,
+        public const byte PickUp = 1;
     }
 
     public override RecvOp OpCode => RecvOp.LIFTABLE;
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        LiftableMode mode = (LiftableMode) packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
-            case LiftableMode.PickUp:
+            case LiftableOperations.PickUp:
                 HandlePickUp(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/LiftableHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/LiftableHandler.cs
@@ -7,7 +7,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class LiftableHandler : GamePacketHandler
+internal sealed class LiftableHandler : GamePacketHandler
 {
     private static class LiftableOperations
     {
@@ -58,7 +58,7 @@ public class LiftableHandler : GamePacketHandler
 
             session.FieldManager.BroadcastPacket(ResponseCubePacket.RemoveCube(fieldPlayer.ObjectId, fieldPlayer.ObjectId, liftable.Position.ToByte()));
             session.FieldManager.BroadcastPacket(LiftablePacket.RemoveCube(liftable));
-            session.FieldManager.BroadcastPacket(BuildModePacket.Use(fieldPlayer, BuildModeHandler.BuildModeType.Liftables, liftable.ItemId));
+            session.FieldManager.BroadcastPacket(BuildModePacket.Use(fieldPlayer, BuildModeHandler.BuildModeTypes.Liftables, liftable.ItemId));
             return;
         }
 
@@ -71,7 +71,7 @@ public class LiftableHandler : GamePacketHandler
         liftable2.Enabled = false;
 
         session.FieldManager.BroadcastPacket(LiftablePacket.UpdateEntityById(liftable2));
-        session.FieldManager.BroadcastPacket(BuildModePacket.Use(fieldPlayer, BuildModeHandler.BuildModeType.Liftables, liftable2.ItemId));
+        session.FieldManager.BroadcastPacket(BuildModePacket.Use(fieldPlayer, BuildModeHandler.BuildModeTypes.Liftables, liftable2.ItemId));
         session.FieldManager.BroadcastPacket(LiftablePacket.UpdateEntityById(liftable2));
     }
 }

--- a/MapleServer2/PacketHandlers/Game/LoadUgcMapHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/LoadUgcMapHandler.cs
@@ -10,7 +10,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class LoadUgcMapHandler : GamePacketHandler
+internal sealed class LoadUgcMapHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_LOAD_UGC_MAP;
 

--- a/MapleServer2/PacketHandlers/Game/MailHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MailHandler.cs
@@ -10,7 +10,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class MailHandler : GamePacketHandler
+internal sealed class MailHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.MAIL;
 
@@ -25,7 +25,7 @@ public class MailHandler : GamePacketHandler
         public const byte CollectBatch = 0x13;
     }
 
-    private static class MailErrorCode
+    private static class MailErrors
     {
         public const byte CharacterNotFound = 0x01;
         public const byte ItemAmountMismatch = 0x02;
@@ -48,9 +48,9 @@ public class MailHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
             case MailOperations.Open:
                 HandleOpen(session);
@@ -74,7 +74,7 @@ public class MailHandler : GamePacketHandler
                 HandleCollectBatch(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }
@@ -101,13 +101,13 @@ public class MailHandler : GamePacketHandler
 
         if (recipientName == session.Player.Name)
         {
-            session.Send(MailPacket.Error(MailErrorCode.CannotMailYourself));
+            session.Send(MailPacket.Error(MailErrors.CannotMailYourself));
             return;
         }
 
         if (!DatabaseManager.Characters.NameExists(recipientName))
         {
-            session.Send(MailPacket.Error(MailErrorCode.CharacterNotFound));
+            session.Send(MailPacket.Error(MailErrors.CharacterNotFound));
             return;
         }
 

--- a/MapleServer2/PacketHandlers/Game/MailHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MailHandler.cs
@@ -14,67 +14,67 @@ public class MailHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.MAIL;
 
-    private enum MailMode : byte
+    private static class MailOperations
     {
-        Open = 0x0,
-        Send = 0x1,
-        Read = 0x2,
-        Collect = 0xB,
-        Delete = 0xD,
-        ReadBatch = 0x12,
-        CollectBatch = 0x13
+        public const byte Open = 0x0;
+        public const byte Send = 0x1;
+        public const byte Read = 0x2;
+        public const byte Collect = 0xB;
+        public const byte Delete = 0xD;
+        public const byte ReadBatch = 0x12;
+        public const byte CollectBatch = 0x13;
     }
 
-    private enum MailErrorCode : byte
+    private static class MailErrorCode
     {
-        CharacterNotFound = 0x01,
-        ItemAmountMismatch = 0x02,
-        ItemCannotBeSent = 0x03,
-        MailNotSent = 0x0C,
-        MailAlreadyRead = 0x10,
-        ItemAlreadyRetrieved = 0x11,
-        FullInventory = 0x14,
-        MailItemExpired = 0x15,
-        SaleEnded = 0x17,
-        MailCreationFailed = 0x18,
-        CannotMailYourself = 0x19,
-        NotEnouhgMeso = 0x1A,
-        PlayerIsBlocked = 0x1B,
-        PlayerBlockedYou = 0x1C,
-        GMCannotSendMail = 0x1D,
-        ContainsForbiddenWord = 0x1F,
-        MailPrivilegeSuspended = 0x20
+        public const byte CharacterNotFound = 0x01;
+        public const byte ItemAmountMismatch = 0x02;
+        public const byte ItemCannotBeSent = 0x03;
+        public const byte MailNotSent = 0x0C;
+        public const byte MailAlreadyRead = 0x10;
+        public const byte ItemAlreadyRetrieved = 0x11;
+        public const byte FullInventory = 0x14;
+        public const byte MailItemExpired = 0x15;
+        public const byte SaleEnded = 0x17;
+        public const byte MailCreationFailed = 0x18;
+        public const byte CannotMailYourself = 0x19;
+        public const byte NotEnouhgMeso = 0x1A;
+        public const byte PlayerIsBlocked = 0x1B;
+        public const byte PlayerBlockedYou = 0x1C;
+        public const byte GMCannotSendMail = 0x1D;
+        public const byte ContainsForbiddenWord = 0x1F;
+        public const byte MailPrivilegeSuspended = 0x20;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        MailMode mode = (MailMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
-            case MailMode.Open:
+            case MailOperations.Open:
                 HandleOpen(session);
                 break;
-            case MailMode.Send:
+            case MailOperations.Send:
                 HandleSend(session, packet);
                 break;
-            case MailMode.Read:
+            case MailOperations.Read:
                 HandleRead(session, packet);
                 break;
-            case MailMode.Collect:
+            case MailOperations.Collect:
                 HandleCollect(session, packet);
                 break;
-            case MailMode.Delete:
+            case MailOperations.Delete:
                 HandleDelete(session, packet);
                 break;
-            case MailMode.ReadBatch:
+            case MailOperations.ReadBatch:
                 HandleReadBatch(session, packet);
                 break;
-            case MailMode.CollectBatch:
+            case MailOperations.CollectBatch:
                 HandleCollectBatch(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }
@@ -101,13 +101,13 @@ public class MailHandler : GamePacketHandler
 
         if (recipientName == session.Player.Name)
         {
-            session.Send(MailPacket.Error((byte) MailErrorCode.CannotMailYourself));
+            session.Send(MailPacket.Error(MailErrorCode.CannotMailYourself));
             return;
         }
 
         if (!DatabaseManager.Characters.NameExists(recipientName))
         {
-            session.Send(MailPacket.Error((byte) MailErrorCode.CharacterNotFound));
+            session.Send(MailPacket.Error(MailErrorCode.CharacterNotFound));
             return;
         }
 

--- a/MapleServer2/PacketHandlers/Game/MapleopolyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MapleopolyHandler.cs
@@ -13,37 +13,37 @@ public class MapleopolyHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.MAPLEOPOLY;
 
-    private enum MapleopolyMode : byte
+    private static class MapleopolyOperations
     {
-        Open = 0x0,
-        Roll = 0x1,
-        ProcessTile = 0x3
+        public const byte Open = 0x0;
+        public const byte Roll = 0x1;
+        public const byte ProcessTile = 0x3;
     }
 
-    private enum MapleopolyNotice : byte
+    private static class MapleopolyNotice
     {
-        NotEnoughTokens = 0x1,
-        DiceAlreadyRolled = 0x4,
-        YouCannotRollRightNow = 0x5
+        public const byte NotEnoughTokens = 0x1;
+        public const byte DiceAlreadyRolled = 0x4;
+        public const byte YouCannotRollRightNow = 0x5;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        MapleopolyMode mode = (MapleopolyMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
-            case MapleopolyMode.Open:
+            case MapleopolyOperations.Open:
                 HandleOpen(session);
                 break;
-            case MapleopolyMode.Roll:
+            case MapleopolyOperations.Roll:
                 HandleRoll(session);
                 break;
-            case MapleopolyMode.ProcessTile:
+            case MapleopolyOperations.ProcessTile:
                 HandleProcessTile(session);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/MapleopolyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MapleopolyHandler.cs
@@ -9,7 +9,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class MapleopolyHandler : GamePacketHandler
+internal sealed class MapleopolyHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.MAPLEOPOLY;
 
@@ -20,7 +20,7 @@ public class MapleopolyHandler : GamePacketHandler
         public const byte ProcessTile = 0x3;
     }
 
-    private static class MapleopolyNotice
+    private static class MapleopolyNotices
     {
         public const byte NotEnoughTokens = 0x1;
         public const byte DiceAlreadyRolled = 0x4;
@@ -29,9 +29,9 @@ public class MapleopolyHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
             case MapleopolyOperations.Open:
                 HandleOpen(session);
@@ -43,7 +43,7 @@ public class MapleopolyHandler : GamePacketHandler
                 HandleProcessTile(session);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }
@@ -76,7 +76,7 @@ public class MapleopolyHandler : GamePacketHandler
         }
         else
         {
-            session.Send(MapleopolyPacket.Notice((byte) MapleopolyNotice.NotEnoughTokens));
+            session.Send(MapleopolyPacket.Notice((byte) MapleopolyNotices.NotEnoughTokens));
             return;
         }
 

--- a/MapleServer2/PacketHandlers/Game/MasteryHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MasteryHandler.cs
@@ -14,34 +14,34 @@ public class MasteryHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.CONSTRUCT_RECIPE;
 
-    private enum MasteryMode : byte
+    private static class MasteryOperations
     {
-        RewardBox = 0x01,
-        CraftItem = 0x02
+        public const byte RewardBox = 0x01;
+        public const byte CraftItem = 0x02;
     }
 
-    private enum MasteryNotice : byte
+    private static class MasteryNotice
     {
-        NotEnoughMastery = 0x01,
-        NotEnoughMesos = 0x02,
-        RequiredQuestIsNotCompleted = 0x03,
-        NotEnoughItems = 0x04,
-        InsufficientLevel = 0x07
+        public const byte NotEnoughMastery = 0x01;
+        public const byte NotEnoughMesos = 0x02;
+        public const byte RequiredQuestIsNotCompleted = 0x03;
+        public const byte NotEnoughItems = 0x04;
+        public const byte InsufficientLevel = 0x07;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        MasteryMode mode = (MasteryMode) packet.ReadByte();
-        switch (mode)
+        var operation = packet.ReadByte();
+        switch (operation)
         {
-            case MasteryMode.RewardBox:
+            case MasteryOperations.RewardBox:
                 HandleRewardBox(session, packet);
                 break;
-            case MasteryMode.CraftItem:
+            case MasteryOperations.CraftItem:
                 HandleCraftItem(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }
@@ -144,7 +144,7 @@ public class MasteryHandler : GamePacketHandler
 
         return true;
     }
-
+    
     private static void AddRewardItemsToInventory(GameSession session, RecipeMetadata recipe)
     {
         // award items

--- a/MapleServer2/PacketHandlers/Game/MasteryHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MasteryHandler.cs
@@ -10,7 +10,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class MasteryHandler : GamePacketHandler
+internal sealed class MasteryHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.CONSTRUCT_RECIPE;
 
@@ -20,7 +20,7 @@ public class MasteryHandler : GamePacketHandler
         public const byte CraftItem = 0x02;
     }
 
-    private static class MasteryNotice
+    private static class MasteryNotices
     {
         public const byte NotEnoughMastery = 0x01;
         public const byte NotEnoughMesos = 0x02;
@@ -89,7 +89,7 @@ public class MasteryHandler : GamePacketHandler
         {
             if (session.Player.Levels.MasteryExp.First(x => x.Type == (MasteryType) recipe.MasteryType).CurrentExp < recipe.RequireMastery)
             {
-                session.Send(MasteryPacket.MasteryNotice((short) MasteryNotice.NotEnoughMastery));
+                session.Send(MasteryPacket.MasteryNotice(MasteryNotices.NotEnoughMastery));
                 return;
             }
         }
@@ -100,7 +100,7 @@ public class MasteryHandler : GamePacketHandler
             {
                 if (session.Player.QuestData.TryGetValue(questId, out QuestStatus quest) && quest.State is not QuestState.Finished)
                 {
-                    session.Send(MasteryPacket.MasteryNotice((short) MasteryNotice.RequiredQuestIsNotCompleted));
+                    session.Send(MasteryPacket.MasteryNotice(MasteryNotices.RequiredQuestIsNotCompleted));
                     return;
                 }
             }
@@ -109,14 +109,14 @@ public class MasteryHandler : GamePacketHandler
         // does the play have enough mesos for this recipe?
         if (!session.Player.Wallet.Meso.Modify(-recipe.RequireMeso))
         {
-            session.Send(MasteryPacket.MasteryNotice((short) MasteryNotice.NotEnoughMesos));
+            session.Send(MasteryPacket.MasteryNotice(MasteryNotices.NotEnoughMesos));
             return;
         }
 
         // does the player have all the required ingredients for this recipe?
         if (!PlayerHasAllIngredients(session, recipe))
         {
-            session.Send(MasteryPacket.MasteryNotice((short) MasteryNotice.NotEnoughItems));
+            session.Send(MasteryPacket.MasteryNotice(MasteryNotices.NotEnoughItems));
             return;
         }
 

--- a/MapleServer2/PacketHandlers/Game/MatchPartyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MatchPartyHandler.cs
@@ -7,7 +7,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class MatchPartyHandler : GamePacketHandler
+internal sealed class MatchPartyHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.MATCH_PARTY;
 
@@ -18,7 +18,7 @@ public class MatchPartyHandler : GamePacketHandler
         public const byte Refresh = 0x2;
     }
 
-    private static class SearchFilter
+    private static class SearchFilters
     {
         public const byte MostMembers = 0xC;
         public const byte LeastMembers = 0xB;
@@ -114,16 +114,16 @@ public class MatchPartyHandler : GamePacketHandler
         //Filter
         switch (filterMode)
         {
-            case SearchFilter.MostMembers:
+            case SearchFilters.MostMembers:
                 partyList = partyList.OrderByDescending(p => p.Members.Count).ToList();
                 break;
-            case SearchFilter.LeastMembers:
+            case SearchFilters.LeastMembers:
                 partyList = partyList.OrderBy(p => p.Members.Count).ToList();
                 break;
-            case SearchFilter.OldestFirst:
+            case SearchFilters.OldestFirst:
                 partyList = partyList.OrderBy(p => p.CreationTimestamp).ToList();
                 break;
-            case SearchFilter.NewestFirst:
+            case SearchFilters.NewestFirst:
                 partyList = partyList.OrderByDescending(p => p.CreationTimestamp).ToList();
                 break;
         }

--- a/MapleServer2/PacketHandlers/Game/MatchPartyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MatchPartyHandler.cs
@@ -11,37 +11,37 @@ public class MatchPartyHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.MATCH_PARTY;
 
-    private enum MatchPartyMode : byte
+    private static class MatchPartyOperations
     {
-        CreateListing = 0x0,
-        RemoveListing = 0x1,
-        Refresh = 0x2
+        public const byte CreateListing = 0x0;
+        public const byte RemoveListing = 0x1;
+        public const byte Refresh = 0x2;
     }
 
-    private enum SearchFilter : byte
+    private static class SearchFilter
     {
-        MostMembers = 0xC,
-        LeastMembers = 0xB,
-        OldestFirst = 0x16,
-        NewestFirst = 0x15
+        public const byte MostMembers = 0xC;
+        public const byte LeastMembers = 0xB;
+        public const byte OldestFirst = 0x16;
+        public const byte NewestFirst = 0x15;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        MatchPartyMode mode = (MatchPartyMode) packet.ReadByte();
-        switch (mode)
+        var operation = packet.ReadByte();
+        switch (operation)
         {
-            case MatchPartyMode.CreateListing:
+            case MatchPartyOperations.CreateListing:
                 HandleCreateListing(session, packet);
                 break;
-            case MatchPartyMode.RemoveListing:
+            case MatchPartyOperations.RemoveListing:
                 HandleRemoveListing(session);
                 break;
-            case MatchPartyMode.Refresh:
+            case MatchPartyOperations.Refresh:
                 HandleRefresh(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }
@@ -105,7 +105,7 @@ public class MatchPartyHandler : GamePacketHandler
     {
         //Get search terms:
         long unk = packet.ReadLong();
-        SearchFilter filterMode = (SearchFilter) packet.ReadByte();
+        var filterMode = packet.ReadByte();
         string searchText = packet.ReadUnicodeString().ToLower();
         long unk2 = packet.ReadLong();
 

--- a/MapleServer2/PacketHandlers/Game/MeretMarketHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MeretMarketHandler.cs
@@ -16,74 +16,74 @@ public class MeretMarketHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.MERET_MARKET;
 
-    private enum MeretMarketMode : byte
+    private static class MeretMarketOperations
     {
-        LoadPersonalListings = 0xB,
-        LoadSales = 0xC,
-        ListItem = 0xD,
-        RemoveListing = 0xE,
-        UnlistItem = 0xF,
-        RelistItem = 0x12,
-        CollectProfit = 0x14,
-        Initialize = 0x16,
-        OpenShop = 0x1B,
-        SendMarketRequest = 0x1D,
-        Purchase = 0x1E,
-        Home = 0x65,
-        OpenDesignShop = 0x66,
-        LoadCart = 0x6B
+        public const byte LoadPersonalListings = 0xB;
+        public const byte LoadSales = 0xC;
+        public const byte ListItem = 0xD;
+        public const byte RemoveListing = 0xE;
+        public const byte UnlistItem = 0xF;
+        public const byte RelistItem = 0x12;
+        public const byte CollectProfit = 0x14;
+        public const byte Initialize = 0x16;
+        public const byte OpenShop = 0x1B;
+        public const byte SendMarketRequest = 0x1D;
+        public const byte Purchase = 0x1E;
+        public const byte Home = 0x65;
+        public const byte OpenDesignShop = 0x66;
+        public const byte LoadCart = 0x6B;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        MeretMarketMode mode = (MeretMarketMode) packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
-            case MeretMarketMode.LoadPersonalListings:
+            case MeretMarketOperations.LoadPersonalListings:
                 HandleLoadPersonalListings(session);
                 break;
-            case MeretMarketMode.LoadSales:
+            case MeretMarketOperations.LoadSales:
                 HandleLoadSales(session);
                 break;
-            case MeretMarketMode.ListItem:
+            case MeretMarketOperations.ListItem:
                 HandleListItem(session, packet);
                 break;
-            case MeretMarketMode.RemoveListing:
+            case MeretMarketOperations.RemoveListing:
                 HandleRemoveListing(session, packet);
                 break;
-            case MeretMarketMode.UnlistItem:
+            case MeretMarketOperations.UnlistItem:
                 HandleUnlistItem(session, packet);
                 break;
-            case MeretMarketMode.RelistItem:
+            case MeretMarketOperations.RelistItem:
                 HandleRelistItem(session, packet);
                 break;
-            case MeretMarketMode.CollectProfit:
+            case MeretMarketOperations.CollectProfit:
                 HandleCollectProfit(session, packet);
                 break;
-            case MeretMarketMode.Initialize:
+            case MeretMarketOperations.Initialize:
                 HandleInitialize(session);
                 break;
-            case MeretMarketMode.OpenShop:
+            case MeretMarketOperations.OpenShop:
                 HandleOpenShop(session, packet);
                 break;
-            case MeretMarketMode.Purchase:
+            case MeretMarketOperations.Purchase:
                 HandlePurchase(session, packet);
                 break;
-            case MeretMarketMode.Home:
+            case MeretMarketOperations.Home:
                 HandleHome(session);
                 break;
-            case MeretMarketMode.OpenDesignShop:
+            case MeretMarketOperations.OpenDesignShop:
                 HandleOpenDesignShop(session);
                 break;
-            case MeretMarketMode.LoadCart:
+            case MeretMarketOperations.LoadCart:
                 HandleLoadCart(session);
                 break;
-            case MeretMarketMode.SendMarketRequest:
+            case MeretMarketOperations.SendMarketRequest:
                 HandleSendMarketRequest(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/MeretMarketHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MeretMarketHandler.cs
@@ -12,7 +12,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class MeretMarketHandler : GamePacketHandler
+internal sealed class MeretMarketHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.MERET_MARKET;
 

--- a/MapleServer2/PacketHandlers/Game/MesoMarketHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MesoMarketHandler.cs
@@ -13,13 +13,13 @@ public class MesoMarketHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.MESO_MARKET;
 
-    private enum MesoMarketMode : byte
+    private static class MesoMarketOperations
     {
-        Load = 0x3,
-        CreateListing = 0x5,
-        CancelListing = 0x6,
-        RefreshListings = 0x7,
-        Purchase = 0x8,
+        public const byte Load = 0x3;
+        public const byte CreateListing = 0x5;
+        public const byte CancelListing = 0x6;
+        public const byte RefreshListings = 0x7;
+        public const byte Purchase = 0x8;
     }
 
     private enum MesoMarketError
@@ -41,27 +41,27 @@ public class MesoMarketHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        MesoMarketMode mode = (MesoMarketMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
-            case MesoMarketMode.Load:
+            case MesoMarketOperations.Load:
                 HandleLoad(session);
                 break;
-            case MesoMarketMode.CreateListing:
+            case MesoMarketOperations.CreateListing:
                 HandleCreateListing(session, packet);
                 break;
-            case MesoMarketMode.CancelListing:
+            case MesoMarketOperations.CancelListing:
                 HandleCancelListing(session, packet);
                 break;
-            case MesoMarketMode.RefreshListings:
+            case MesoMarketOperations.RefreshListings:
                 HandleRefreshListings(session, packet);
                 break;
-            case MesoMarketMode.Purchase:
+            case MesoMarketOperations.Purchase:
                 HandlePurchase(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/MoveFieldHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MoveFieldHandler.cs
@@ -12,7 +12,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class MoveFieldHandler : GamePacketHandler
+internal sealed class MoveFieldHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_MOVE_FIELD;
 

--- a/MapleServer2/PacketHandlers/Game/MoveFieldHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MoveFieldHandler.cs
@@ -16,38 +16,38 @@ public class MoveFieldHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_MOVE_FIELD;
 
-    private enum RequestMoveFieldMode : byte
+    private static class RequestMoveFieldOperations
     {
-        Move = 0x0,
-        LeaveInstance = 0x1,
-        VisitHouse = 0x02,
-        ReturnMap = 0x03,
-        EnterDecorPlaner = 0x04
+        public const byte Move = 0x0;
+        public const byte LeaveInstance = 0x1;
+        public const byte VisitHouse = 0x02;
+        public const byte ReturnMap = 0x03;
+        public const byte EnterDecorPlaner = 0x04;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        RequestMoveFieldMode mode = (RequestMoveFieldMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
-            case RequestMoveFieldMode.Move:
+            case RequestMoveFieldOperations.Move:
                 HandleMove(session, packet);
                 break;
-            case RequestMoveFieldMode.LeaveInstance:
+            case RequestMoveFieldOperations.LeaveInstance:
                 HandleLeaveInstance(session);
                 break;
-            case RequestMoveFieldMode.VisitHouse:
+            case RequestMoveFieldOperations.VisitHouse:
                 HandleVisitHouse(session, packet);
                 break;
-            case RequestMoveFieldMode.ReturnMap:
+            case RequestMoveFieldOperations.ReturnMap:
                 HandleReturnMap(session);
                 break;
-            case RequestMoveFieldMode.EnterDecorPlaner:
+            case RequestMoveFieldOperations.EnterDecorPlaner:
                 HandleEnterDecorPlaner(session);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/MyInfoHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MyInfoHandler.cs
@@ -5,7 +5,7 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class MyInfoHandler : GamePacketHandler
+internal sealed class MyInfoHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.MY_INFO;
 

--- a/MapleServer2/PacketHandlers/Game/NewsNotificationHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/NewsNotificationHandler.cs
@@ -9,27 +9,27 @@ public class NewsNotificationHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.NEWS_NOTIFICATION;
 
-    private enum NewsNotificationMode : byte
+    private static class NewsNotificationOperations
     {
-        OpenBrowser = 0x0,
-        OpenSidebar = 0x2
+        public const byte OpenBrowser = 0x0;
+        public const byte OpenSidebar = 0x2;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
         short unk = packet.ReadShort();
-        NewsNotificationMode mode = (NewsNotificationMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
-            case NewsNotificationMode.OpenBrowser:
+            case NewsNotificationOperations.OpenBrowser:
                 HandleOpenBrowser(session);
                 break;
-            case NewsNotificationMode.OpenSidebar:
+            case NewsNotificationOperations.OpenSidebar:
                 HandleOpenSidebar(session);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/NewsNotificationHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/NewsNotificationHandler.cs
@@ -5,7 +5,7 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class NewsNotificationHandler : GamePacketHandler
+internal sealed class NewsNotificationHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.NEWS_NOTIFICATION;
 

--- a/MapleServer2/PacketHandlers/Game/NpcTalkHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/NpcTalkHandler.cs
@@ -16,12 +16,12 @@ public class NpcTalkHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.NPC_TALK;
 
-    private enum NpcTalkMode : byte
+    private static class NpcTalkOperations
     {
-        Close = 0,
-        Respond = 1,
-        Continue = 2,
-        NextQuest = 7
+        public const byte Close = 0;
+        public const byte Respond = 1;
+        public const byte Continue = 2;
+        public const byte NextQuest = 7;
     }
 
     private enum ScriptIdType : byte
@@ -33,22 +33,22 @@ public class NpcTalkHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        NpcTalkMode function = (NpcTalkMode) packet.ReadByte();
-        switch (function)
+        var operation = packet.ReadByte();
+        switch (operation)
         {
-            case NpcTalkMode.Close:
+            case NpcTalkOperations.Close:
                 return;
-            case NpcTalkMode.Respond:
+            case NpcTalkOperations.Respond:
                 HandleRespond(session, packet);
                 break;
-            case NpcTalkMode.Continue:
+            case NpcTalkOperations.Continue:
                 HandleContinue(session, packet.ReadInt());
                 break;
-            case NpcTalkMode.NextQuest:
+            case NpcTalkOperations.NextQuest:
                 HandleNextQuest(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(function);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/NpcTalkHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/NpcTalkHandler.cs
@@ -12,7 +12,7 @@ using MoonSharp.Interpreter;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class NpcTalkHandler : GamePacketHandler
+internal sealed class NpcTalkHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.NPC_TALK;
 
@@ -24,11 +24,11 @@ public class NpcTalkHandler : GamePacketHandler
         public const byte NextQuest = 7;
     }
 
-    private enum ScriptIdType : byte
+    private static class ScriptIdTypes
     {
-        Start = 1,
-        Continue = 2,
-        End = 3
+        public const byte Start = 1;
+        public const byte Continue = 2;
+        public const byte End = 3;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
@@ -310,13 +310,13 @@ public class NpcTalkHandler : GamePacketHandler
         if (!hasNextScript)
         {
             // Get the correct dialog type for the last quest content
-            ScriptIdType type = (ScriptIdType) (npcTalk.ScriptId / 100);
+            var type = npcTalk.ScriptId / 100;
             if (npcTalk.IsQuest)
             {
                 return type switch
                 {
-                    ScriptIdType.Start => DialogType.AcceptDecline,
-                    ScriptIdType.End => DialogType.QuestReward,
+                    ScriptIdTypes.Start => DialogType.AcceptDecline,
+                    ScriptIdTypes.End => DialogType.QuestReward,
                     _ => DialogType.Close1
                 };
             }

--- a/MapleServer2/PacketHandlers/Game/PartyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/PartyHandler.cs
@@ -11,63 +11,63 @@ public class PartyHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.PARTY;
 
-    private enum PartyMode : byte
+    private static class PartyOperations
     {
-        Invite = 0x1,
-        Join = 0x2,
-        Leave = 0x3,
-        Kick = 0x4,
-        SetLeader = 0x11,
-        FinderJoin = 0x17,
-        SummonParty = 0x1D,
-        VoteKick = 0x2D,
-        ReadyCheck = 0x2E,
-        FindDungeonParty = 0x21,
-        CancelFindDungeonParty = 0x22,
-        ReadyCheckUpdate = 0x30
+        public const byte Invite = 0x1;
+        public const byte Join = 0x2;
+        public const byte Leave = 0x3;
+        public const byte Kick = 0x4;
+        public const byte SetLeader = 0x11;
+        public const byte FinderJoin = 0x17;
+        public const byte SummonParty = 0x1D;
+        public const byte VoteKick = 0x2D;
+        public const byte ReadyCheck = 0x2E;
+        public const byte FindDungeonParty = 0x21;
+        public const byte CancelFindDungeonParty = 0x22;
+        public const byte ReadyCheckUpdate = 0x30;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        PartyMode mode = (PartyMode) packet.ReadByte(); //Mode
+        var operation = packet.ReadByte(); //Mode
 
-        switch (mode)
+        switch (operation)
         {
-            case PartyMode.Invite:
+            case PartyOperations.Invite:
                 HandleInvite(session, packet);
                 break;
-            case PartyMode.Join:
+            case PartyOperations.Join:
                 HandleJoin(session, packet);
                 break;
-            case PartyMode.Leave:
+            case PartyOperations.Leave:
                 HandleLeave(session);
                 break;
-            case PartyMode.Kick:
+            case PartyOperations.Kick:
                 HandleKick(session, packet);
                 break;
-            case PartyMode.SetLeader:
+            case PartyOperations.SetLeader:
                 HandleSetLeader(session, packet);
                 break;
-            case PartyMode.FinderJoin:
+            case PartyOperations.FinderJoin:
                 HandleFinderJoin(session, packet);
                 break;
-            case PartyMode.SummonParty:
+            case PartyOperations.SummonParty:
                 HandleSummonParty();
                 break;
-            case PartyMode.VoteKick:
+            case PartyOperations.VoteKick:
                 HandleVoteKick(session, packet);
                 break;
-            case PartyMode.ReadyCheck:
+            case PartyOperations.ReadyCheck:
                 HandleStartReadyCheck(session);
                 break;
-            case PartyMode.FindDungeonParty:
+            case PartyOperations.FindDungeonParty:
                 HandleFindDungeonParty(session, packet);
                 break;
-            case PartyMode.ReadyCheckUpdate:
+            case PartyOperations.ReadyCheckUpdate:
                 HandleReadyCheckUpdate(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/PartyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/PartyHandler.cs
@@ -7,7 +7,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class PartyHandler : GamePacketHandler
+internal sealed class PartyHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.PARTY;
 

--- a/MapleServer2/PacketHandlers/Game/PlayerHostHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/PlayerHostHandler.cs
@@ -10,22 +10,22 @@ public class PlayerHostHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.PLAYER_HOST;
 
-    private enum PlayerHostMode : byte
+    private static class PlayerHostOperations
     {
-        Claim = 0x1
+        public const byte Claim = 0x1;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        PlayerHostMode mode = (PlayerHostMode) packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
-            case PlayerHostMode.Claim:
+            case PlayerHostOperations.Claim:
                 HandleClaim(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/PlayerHostHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/PlayerHostHandler.cs
@@ -6,7 +6,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class PlayerHostHandler : GamePacketHandler
+internal sealed class PlayerHostHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.PLAYER_HOST;
 

--- a/MapleServer2/PacketHandlers/Game/PremiumClubHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/PremiumClubHandler.cs
@@ -13,34 +13,34 @@ public class PremiumClubHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.PREMIUM_CLUB;
 
-    private enum PremiumClubMode : byte
+    private static class PremiumClubOperations
     {
-        Open = 0x1,
-        ClaimItems = 0x2,
-        OpenPurchaseWindow = 0x3,
-        PurchaseMembership = 0x4
+        public const byte Open = 0x1;
+        public const byte ClaimItems = 0x2;
+        public const byte OpenPurchaseWindow = 0x3;
+        public const byte PurchaseMembership = 0x4;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        PremiumClubMode mode = (PremiumClubMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
-            case PremiumClubMode.Open:
+            case PremiumClubOperations.Open:
                 HandleOpen(session);
                 break;
-            case PremiumClubMode.ClaimItems:
+            case PremiumClubOperations.ClaimItems:
                 HandleClaimItems(session, packet);
                 break;
-            case PremiumClubMode.OpenPurchaseWindow:
+            case PremiumClubOperations.OpenPurchaseWindow:
                 HandleOpenPurchaseWindow(session);
                 break;
-            case PremiumClubMode.PurchaseMembership:
+            case PremiumClubOperations.PurchaseMembership:
                 HandlePurchaseMembership(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/PremiumClubHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/PremiumClubHandler.cs
@@ -9,7 +9,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class PremiumClubHandler : GamePacketHandler
+internal sealed class PremiumClubHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.PREMIUM_CLUB;
 
@@ -23,9 +23,9 @@ public class PremiumClubHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
             case PremiumClubOperations.Open:
                 HandleOpen(session);
@@ -40,7 +40,7 @@ public class PremiumClubHandler : GamePacketHandler
                 HandlePurchaseMembership(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/PrestigeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/PrestigeHandler.cs
@@ -12,17 +12,17 @@ public class PrestigeHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.PRESTIGE;
 
-    private enum PrestigeMode : byte
+    private static class PrestigeOperation
     {
-        Reward = 0x03
+        public const byte Reward = 0x03;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        PrestigeMode mode = (PrestigeMode) packet.ReadByte();
-        switch (mode)
+        var operation = packet.ReadByte();
+        switch (operation)
         {
-            case PrestigeMode.Reward: // Receive reward
+            case PrestigeOperation.Reward: // Receive reward
                 HandleReward(session, packet);
                 break;
         }

--- a/MapleServer2/PacketHandlers/Game/PrestigeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/PrestigeHandler.cs
@@ -8,11 +8,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class PrestigeHandler : GamePacketHandler
+internal sealed class PrestigeHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.PRESTIGE;
 
-    private static class PrestigeOperation
+    private static class PrestigeOperations
     {
         public const byte Reward = 0x03;
     }
@@ -22,7 +22,7 @@ public class PrestigeHandler : GamePacketHandler
         var operation = packet.ReadByte();
         switch (operation)
         {
-            case PrestigeOperation.Reward: // Receive reward
+            case PrestigeOperations.Reward: // Receive reward
                 HandleReward(session, packet);
                 break;
         }

--- a/MapleServer2/PacketHandlers/Game/QuestHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/QuestHandler.cs
@@ -10,7 +10,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class QuestHandler : GamePacketHandler
+internal sealed class QuestHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.QUEST;
 

--- a/MapleServer2/PacketHandlers/Game/QuestHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/QuestHandler.cs
@@ -14,38 +14,38 @@ public class QuestHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.QUEST;
 
-    private enum QuestMode : byte
+    private static class QuestOperations
     {
-        AcceptQuest = 0x02,
-        CompleteQuest = 0x04,
-        ExplorationQuests = 0x08,
-        ToggleTracking = 0x09,
-        CompleteNavigator = 0x18
+        public const byte AcceptQuest = 0x02;
+        public const byte CompleteQuest = 0x04;
+        public const byte ExplorationQuests = 0x08;
+        public const byte ToggleTracking = 0x09;
+        public const byte CompleteNavigator = 0x18;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        QuestMode mode = (QuestMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
-            case QuestMode.AcceptQuest:
+            case QuestOperations.AcceptQuest:
                 HandleAcceptQuest(session, packet);
                 break;
-            case QuestMode.CompleteQuest:
+            case QuestOperations.CompleteQuest:
                 HandleCompleteQuest(session, packet);
                 break;
-            case QuestMode.ExplorationQuests:
+            case QuestOperations.ExplorationQuests:
                 HandleAddExplorationQuests(session, packet);
                 break;
-            case QuestMode.CompleteNavigator:
+            case QuestOperations.CompleteNavigator:
                 HandleCompleteNavigator(session, packet);
                 break;
-            case QuestMode.ToggleTracking:
+            case QuestOperations.ToggleTracking:
                 HandleToggleTracking(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RequestCubeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestCubeHandler.cs
@@ -20,140 +20,140 @@ public class RequestCubeHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_CUBE;
 
-    private enum RequestCubeMode : byte
+    private static class RequestCubeOperations
     {
-        LoadFurnishingItem = 0x1,
-        BuyPlot = 0x2,
-        ForfeitPlot = 0x6,
-        HandleAddFurnishing = 0xA,
-        RemoveCube = 0xC,
-        RotateCube = 0xE,
-        ReplaceCube = 0xF,
-        Pickup = 0x11,
-        Drop = 0x12,
-        HomeName = 0x15,
-        HomePassword = 0x18,
-        NominateHouse = 0x19,
-        HomeDescription = 0x1D,
-        ClearInterior = 0x1F,
-        RequestLayout = 0x23,
-        IncreaseSize = 0x25,
-        DecreaseSize = 0x26,
-        DecorationReward = 0x28,
-        InteriorDesingReward = 0x29,
-        EnablePermission = 0x2A,
-        SetPermission = 0x2B,
-        IncreaseHeight = 0x2C,
-        DecreaseHeight = 0x2D,
-        SaveLayout = 0x2E,
-        DecorPlannerLoadLayout = 0x2F,
-        LoadLayout = 0x30,
-        KickEveryone = 0x31,
-        ChangeBackground = 0x33,
-        ChangeLighting = 0x34,
-        ChangeCamera = 0x36,
-        UpdateBudget = 0x38,
-        GiveBuildingPermission = 0x39,
-        RemoveBuildingPermission = 0x3A
+        public const byte LoadFurnishingItem = 0x1;
+        public const byte BuyPlot = 0x2;
+        public const byte ForfeitPlot = 0x6;
+        public const byte HandleAddFurnishing = 0xA;
+        public const byte RemoveCube = 0xC;
+        public const byte RotateCube = 0xE;
+        public const byte ReplaceCube = 0xF;
+        public const byte Pickup = 0x11;
+        public const byte Drop = 0x12;
+        public const byte HomeName = 0x15;
+        public const byte HomePassword = 0x18;
+        public const byte NominateHouse = 0x19;
+        public const byte HomeDescription = 0x1D;
+        public const byte ClearInterior = 0x1F;
+        public const byte RequestLayout = 0x23;
+        public const byte IncreaseSize = 0x25;
+        public const byte DecreaseSize = 0x26;
+        public const byte DecorationReward = 0x28;
+        public const byte InteriorDesingReward = 0x29;
+        public const byte EnablePermission = 0x2A;
+        public const byte SetPermission = 0x2B;
+        public const byte IncreaseHeight = 0x2C;
+        public const byte DecreaseHeight = 0x2D;
+        public const byte SaveLayout = 0x2E;
+        public const byte DecorPlannerLoadLayout = 0x2F;
+        public const byte LoadLayout = 0x30;
+        public const byte KickEveryone = 0x31;
+        public const byte ChangeBackground = 0x33;
+        public const byte ChangeLighting = 0x34;
+        public const byte ChangeCamera = 0x36;
+        public const byte UpdateBudget = 0x38;
+        public const byte GiveBuildingPermission = 0x39;
+        public const byte RemoveBuildingPermission = 0x3A;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        RequestCubeMode mode = (RequestCubeMode) packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
-            case RequestCubeMode.LoadFurnishingItem:
+            case RequestCubeOperations.LoadFurnishingItem:
                 HandleLoadFurnishingItem(session, packet);
                 break;
-            case RequestCubeMode.BuyPlot:
+            case RequestCubeOperations.BuyPlot:
                 HandleBuyPlot(session, packet);
                 break;
-            case RequestCubeMode.ForfeitPlot:
+            case RequestCubeOperations.ForfeitPlot:
                 HandleForfeitPlot(session);
                 break;
-            case RequestCubeMode.HandleAddFurnishing:
+            case RequestCubeOperations.HandleAddFurnishing:
                 HandleAddFurnishing(session, packet);
                 break;
-            case RequestCubeMode.RemoveCube:
+            case RequestCubeOperations.RemoveCube:
                 HandleRemoveCube(session, packet);
                 break;
-            case RequestCubeMode.RotateCube:
+            case RequestCubeOperations.RotateCube:
                 HandleRotateCube(session, packet);
                 break;
-            case RequestCubeMode.ReplaceCube:
+            case RequestCubeOperations.ReplaceCube:
                 HandleReplaceCube(session, packet);
                 break;
-            case RequestCubeMode.Pickup:
+            case RequestCubeOperations.Pickup:
                 HandlePickup(session, packet);
                 break;
-            case RequestCubeMode.Drop:
+            case RequestCubeOperations.Drop:
                 HandleDrop(session);
                 break;
-            case RequestCubeMode.HomeName:
+            case RequestCubeOperations.HomeName:
                 HandleHomeName(session, packet);
                 break;
-            case RequestCubeMode.HomePassword:
+            case RequestCubeOperations.HomePassword:
                 HandleHomePassword(session, packet);
                 break;
-            case RequestCubeMode.NominateHouse:
+            case RequestCubeOperations.NominateHouse:
                 HandleNominateHouse(session);
                 break;
-            case RequestCubeMode.HomeDescription:
+            case RequestCubeOperations.HomeDescription:
                 HandleHomeDescription(session, packet);
                 break;
-            case RequestCubeMode.ClearInterior:
+            case RequestCubeOperations.ClearInterior:
                 HandleClearInterior(session);
                 break;
-            case RequestCubeMode.RequestLayout:
+            case RequestCubeOperations.RequestLayout:
                 HandleRequestLayout(session, packet);
                 break;
-            case RequestCubeMode.IncreaseSize:
-            case RequestCubeMode.DecreaseSize:
-            case RequestCubeMode.IncreaseHeight:
-            case RequestCubeMode.DecreaseHeight:
-                HandleModifySize(session, mode);
+            case RequestCubeOperations.IncreaseSize:
+            case RequestCubeOperations.DecreaseSize:
+            case RequestCubeOperations.IncreaseHeight:
+            case RequestCubeOperations.DecreaseHeight:
+                HandleModifySize(session, operation);
                 break;
-            case RequestCubeMode.DecorationReward:
+            case RequestCubeOperations.DecorationReward:
                 HandleDecorationReward(session);
                 break;
-            case RequestCubeMode.InteriorDesingReward:
+            case RequestCubeOperations.InteriorDesingReward:
                 HandleInteriorDesingReward(session, packet);
                 break;
-            case RequestCubeMode.SaveLayout:
+            case RequestCubeOperations.SaveLayout:
                 HandleSaveLayout(session, packet);
                 break;
-            case RequestCubeMode.DecorPlannerLoadLayout:
+            case RequestCubeOperations.DecorPlannerLoadLayout:
                 HandleDecorPlannerLoadLayout(session, packet);
                 break;
-            case RequestCubeMode.LoadLayout:
+            case RequestCubeOperations.LoadLayout:
                 HandleLoadLayout(session, packet);
                 break;
-            case RequestCubeMode.KickEveryone:
+            case RequestCubeOperations.KickEveryone:
                 HandleKickEveryone(session);
                 break;
-            case RequestCubeMode.ChangeLighting:
-            case RequestCubeMode.ChangeBackground:
-            case RequestCubeMode.ChangeCamera:
-                HandleModifyInteriorSettings(session, mode, packet);
+            case RequestCubeOperations.ChangeLighting:
+            case RequestCubeOperations.ChangeBackground:
+            case RequestCubeOperations.ChangeCamera:
+                HandleModifyInteriorSettings(session, operation, packet);
                 break;
-            case RequestCubeMode.EnablePermission:
+            case RequestCubeOperations.EnablePermission:
                 HandleEnablePermission(session, packet);
                 break;
-            case RequestCubeMode.SetPermission:
+            case RequestCubeOperations.SetPermission:
                 HandleSetPermission(session, packet);
                 break;
-            case RequestCubeMode.UpdateBudget:
+            case RequestCubeOperations.UpdateBudget:
                 HandleUpdateBudget(session, packet);
                 break;
-            case RequestCubeMode.GiveBuildingPermission:
+            case RequestCubeOperations.GiveBuildingPermission:
                 HandleGiveBuildingPermission(session, packet);
                 break;
-            case RequestCubeMode.RemoveBuildingPermission:
+            case RequestCubeOperations.RemoveBuildingPermission:
                 HandleRemoveBuildingPermission(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }
@@ -827,7 +827,7 @@ public class RequestCubeHandler : GamePacketHandler
         session.SendNotice("Layout loaded succesfully!"); // TODO: Use notice packet
     }
 
-    private static void HandleModifySize(GameSession session, RequestCubeMode mode)
+    private static void HandleModifySize(GameSession session, byte operation)
     {
         Home home = GameServer.HomeManager.GetHomeById(session.Player.VisitingHomeId);
         if (session.Player.AccountId != home.AccountId)
@@ -835,57 +835,57 @@ public class RequestCubeHandler : GamePacketHandler
             return;
         }
 
-        if (mode == RequestCubeMode.IncreaseSize && home.Size + 1 > 25 || mode == RequestCubeMode.IncreaseHeight && home.Height + 1 > 15)
+        if (operation == RequestCubeOperations.IncreaseSize && home.Size + 1 > 25 || operation == RequestCubeOperations.IncreaseHeight && home.Height + 1 > 15)
         {
             return;
         }
 
-        if (mode == RequestCubeMode.DecreaseSize && home.Size - 1 < 4 || mode == RequestCubeMode.DecreaseHeight && home.Height - 1 < 3)
+        if (operation == RequestCubeOperations.DecreaseSize && home.Size - 1 < 4 || operation == RequestCubeOperations.DecreaseHeight && home.Height - 1 < 3)
         {
             return;
         }
 
-        RemoveBlocks(session, mode, home);
+        RemoveBlocks(session, operation, home);
 
         if (session.Player.IsInDecorPlanner)
         {
-            switch (mode)
+            switch (operation)
             {
-                case RequestCubeMode.IncreaseSize:
+                case RequestCubeOperations.IncreaseSize:
                     session.FieldManager.BroadcastPacket(ResponseCubePacket.IncreaseSize(++home.DecorPlannerSize));
                     break;
-                case RequestCubeMode.DecreaseSize:
+                case RequestCubeOperations.DecreaseSize:
                     session.FieldManager.BroadcastPacket(ResponseCubePacket.DecreaseSize(--home.DecorPlannerSize));
                     break;
-                case RequestCubeMode.IncreaseHeight:
+                case RequestCubeOperations.IncreaseHeight:
                     session.FieldManager.BroadcastPacket(ResponseCubePacket.IncreaseHeight(++home.DecorPlannerHeight));
                     break;
-                case RequestCubeMode.DecreaseHeight:
+                case RequestCubeOperations.DecreaseHeight:
                     session.FieldManager.BroadcastPacket(ResponseCubePacket.DecreaseHeight(--home.DecorPlannerHeight));
                     break;
             }
         }
         else
         {
-            switch (mode)
+            switch (operation)
             {
-                case RequestCubeMode.IncreaseSize:
+                case RequestCubeOperations.IncreaseSize:
                     session.FieldManager.BroadcastPacket(ResponseCubePacket.IncreaseSize(++home.Size));
                     break;
-                case RequestCubeMode.DecreaseSize:
+                case RequestCubeOperations.DecreaseSize:
                     session.FieldManager.BroadcastPacket(ResponseCubePacket.DecreaseSize(--home.Size));
                     break;
-                case RequestCubeMode.IncreaseHeight:
+                case RequestCubeOperations.IncreaseHeight:
                     session.FieldManager.BroadcastPacket(ResponseCubePacket.IncreaseHeight(++home.Height));
                     break;
-                case RequestCubeMode.DecreaseHeight:
+                case RequestCubeOperations.DecreaseHeight:
                     session.FieldManager.BroadcastPacket(ResponseCubePacket.DecreaseHeight(--home.Height));
                     break;
             }
         }
 
         // move players to safe coord
-        if (mode == RequestCubeMode.DecreaseHeight || mode == RequestCubeMode.DecreaseSize)
+        if (operation == RequestCubeOperations.DecreaseHeight || operation == RequestCubeOperations.DecreaseSize)
         {
             int x;
             if (session.Player.IsInDecorPlanner)
@@ -1134,22 +1134,22 @@ public class RequestCubeHandler : GamePacketHandler
         session.FieldManager.BroadcastPacket(ResponseCubePacket.UpdateBudget(home));
     }
 
-    private static void HandleModifyInteriorSettings(GameSession session, RequestCubeMode mode, PacketReader packet)
+    private static void HandleModifyInteriorSettings(GameSession session, byte operation, PacketReader packet)
     {
         byte value = packet.ReadByte();
 
         Home home = GameServer.HomeManager.GetHomeById(session.Player.VisitingHomeId);
-        switch (mode)
+        switch (operation)
         {
-            case RequestCubeMode.ChangeBackground:
+            case RequestCubeOperations.ChangeBackground:
                 home.Background = value;
                 session.FieldManager.BroadcastPacket(ResponseCubePacket.ChangeLighting(value));
                 break;
-            case RequestCubeMode.ChangeLighting:
+            case RequestCubeOperations.ChangeLighting:
                 home.Lighting = value;
                 session.FieldManager.BroadcastPacket(ResponseCubePacket.ChangeBackground(value));
                 break;
-            case RequestCubeMode.ChangeCamera:
+            case RequestCubeOperations.ChangeCamera:
                 home.Camera = value;
                 session.FieldManager.BroadcastPacket(ResponseCubePacket.ChangeCamera(value));
                 break;
@@ -1317,9 +1317,9 @@ public class RequestCubeHandler : GamePacketHandler
         return null;
     }
 
-    private static void RemoveBlocks(GameSession session, RequestCubeMode mode, Home home)
+    private static void RemoveBlocks(GameSession session, byte operation, Home home)
     {
-        if (mode == RequestCubeMode.DecreaseSize)
+        if (operation == RequestCubeOperations.DecreaseSize)
         {
             int maxSize = (home.Size - 1) * Block.BLOCK_SIZE * -1;
             for (int i = 0; i < home.Size; i++)
@@ -1349,7 +1349,7 @@ public class RequestCubeHandler : GamePacketHandler
             }
         }
 
-        if (mode == RequestCubeMode.DecreaseHeight)
+        if (operation == RequestCubeOperations.DecreaseHeight)
         {
             for (int i = 0; i < home.Size; i++)
             {

--- a/MapleServer2/PacketHandlers/Game/RequestCubeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestCubeHandler.cs
@@ -16,7 +16,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestCubeHandler : GamePacketHandler
+internal sealed class RequestCubeHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_CUBE;
 
@@ -387,7 +387,7 @@ public class RequestCubeHandler : GamePacketHandler
 
         fieldManager.BroadcastPacket(LiftablePacket.Drop(liftable));
         fieldManager.BroadcastPacket(ResponseCubePacket.PlaceLiftable(liftable, player.FieldPlayer.ObjectId));
-        fieldManager.BroadcastPacket(BuildModePacket.Use(player.FieldPlayer, BuildModeHandler.BuildModeType.Stop));
+        fieldManager.BroadcastPacket(BuildModePacket.Use(player.FieldPlayer, BuildModeHandler.BuildModeTypes.Stop));
         fieldManager.BroadcastPacket(LiftablePacket.UpdateEntityByCoord(liftable));
     }
 

--- a/MapleServer2/PacketHandlers/Game/RequestGemEquipmentHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestGemEquipmentHandler.cs
@@ -10,30 +10,30 @@ public class RequestGemEquipmentHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_GEM_EQUIPMENT;
 
-    private enum RequestGemEquipmentMode : byte
+    private static class RequestGemEquipmentOperations
     {
-        EquipItem = 0x00,
-        UnequipItem = 0x01,
-        Transprency = 0x03
+        public const byte EquipItem = 0x00;
+        public const byte UnequipItem = 0x01;
+        public const byte Transprency = 0x03;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        RequestGemEquipmentMode mode = (RequestGemEquipmentMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
-            case RequestGemEquipmentMode.EquipItem:
+            case RequestGemEquipmentOperations.EquipItem:
                 HandleEquipItem(session, packet);
                 break;
-            case RequestGemEquipmentMode.UnequipItem:
+            case RequestGemEquipmentOperations.UnequipItem:
                 HandleUnequipItem(session, packet);
                 break;
-            case RequestGemEquipmentMode.Transprency:
+            case RequestGemEquipmentOperations.Transprency:
                 HandleTransparency(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RequestGemEquipmentHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestGemEquipmentHandler.cs
@@ -6,7 +6,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestGemEquipmentHandler : GamePacketHandler
+internal sealed class RequestGemEquipmentHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_GEM_EQUIPMENT;
 
@@ -19,9 +19,9 @@ public class RequestGemEquipmentHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
             case RequestGemEquipmentOperations.EquipItem:
                 HandleEquipItem(session, packet);
@@ -33,7 +33,7 @@ public class RequestGemEquipmentHandler : GamePacketHandler
                 HandleTransparency(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RequestHomeBankHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestHomeBankHandler.cs
@@ -6,11 +6,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestHomeBankHandler : GamePacketHandler
+internal sealed class RequestHomeBankHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_HOME_BANK;
 
-    private static class BankMode
+    private static class BankOperations
     {
         public const byte House = 0x01;
         public const byte Inventory = 0x02;
@@ -18,17 +18,17 @@ public class RequestHomeBankHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
-        switch (mode)
+        var operation = packet.ReadByte();
+        switch (operation)
         {
-            case BankMode.House:
+            case BankOperations.House:
                 HandleOpen(session, TimeInfo.Now());
                 break;
-            case BankMode.Inventory:
+            case BankOperations.Inventory:
                 HandleOpen(session);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RequestHomeBankHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestHomeBankHandler.cs
@@ -10,15 +10,15 @@ public class RequestHomeBankHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_HOME_BANK;
 
-    private enum BankMode : byte
+    private static class BankMode
     {
-        House = 0x01,
-        Inventory = 0x02
+        public const byte House = 0x01;
+        public const byte Inventory = 0x02;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        BankMode mode = (BankMode) packet.ReadByte();
+        var mode = packet.ReadByte();
         switch (mode)
         {
             case BankMode.House:
@@ -28,7 +28,7 @@ public class RequestHomeBankHandler : GamePacketHandler
                 HandleOpen(session);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RequestHomeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestHomeHandler.cs
@@ -6,11 +6,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestHomeHandler : GamePacketHandler
+internal sealed class RequestHomeHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_HOME;
 
-    private static class RequestHomeMode
+    private static class RequestHomeOperations
     {
         public const byte InviteToHome = 0x01;
         public const byte MoveToHome = 0x03;
@@ -18,17 +18,17 @@ public class RequestHomeHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
-        switch (mode)
+        var operation = packet.ReadByte();
+        switch (operation)
         {
-            case RequestHomeMode.InviteToHome:
+            case RequestHomeOperations.InviteToHome:
                 HandleInviteToHome(session, packet);
                 break;
-            case RequestHomeMode.MoveToHome:
+            case RequestHomeOperations.MoveToHome:
                 HandleMoveToHome(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RequestHomeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestHomeHandler.cs
@@ -10,15 +10,15 @@ public class RequestHomeHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_HOME;
 
-    private enum RequestHomeMode : byte
+    private static class RequestHomeMode
     {
-        InviteToHome = 0x01,
-        MoveToHome = 0x03
+        public const byte InviteToHome = 0x01;
+        public const byte MoveToHome = 0x03;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        RequestHomeMode mode = (RequestHomeMode) packet.ReadByte();
+        var mode = packet.ReadByte();
         switch (mode)
         {
             case RequestHomeMode.InviteToHome:
@@ -28,7 +28,7 @@ public class RequestHomeHandler : GamePacketHandler
                 HandleMoveToHome(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RequestItemBreakHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemBreakHandler.cs
@@ -5,11 +5,11 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestItemBreakHandler : GamePacketHandler
+internal sealed class RequestItemBreakHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_ITEM_BREAK;
 
-    private static class ItemBreakMode
+    private static class ItemBreakOperations
     {
         public const byte Open = 0x00;
         public const byte Add = 0x01;
@@ -20,27 +20,27 @@ public class RequestItemBreakHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
-        switch (mode)
+        var operation = packet.ReadByte();
+        switch (operation)
         {
-            case ItemBreakMode.Open:
+            case ItemBreakOperations.Open:
                 session.Player.DismantleInventory.Slots = new Tuple<long, int>[100];
                 session.Player.DismantleInventory.Rewards = new();
                 break;
-            case ItemBreakMode.Add:
+            case ItemBreakOperations.Add:
                 HandleAdd(session, packet);
                 break;
-            case ItemBreakMode.Remove:
+            case ItemBreakOperations.Remove:
                 HandleRemove(session, packet);
                 break;
-            case ItemBreakMode.Dismantle:
+            case ItemBreakOperations.Dismantle:
                 HandleDismantle(session);
                 break;
-            case ItemBreakMode.AutoAdd:
+            case ItemBreakOperations.AutoAdd:
                 HandleAutoAdd(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RequestItemBreakHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemBreakHandler.cs
@@ -9,18 +9,18 @@ public class RequestItemBreakHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_ITEM_BREAK;
 
-    private enum ItemBreakMode : byte
+    private static class ItemBreakMode
     {
-        Open = 0x00,
-        Add = 0x01,
-        Remove = 0x02,
-        Dismantle = 0x03,
-        AutoAdd = 0x06
+        public const byte Open = 0x00;
+        public const byte Add = 0x01;
+        public const byte Remove = 0x02;
+        public const byte Dismantle = 0x03;
+        public const byte AutoAdd = 0x06;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ItemBreakMode mode = (ItemBreakMode) packet.ReadByte();
+        var mode = packet.ReadByte();
         switch (mode)
         {
             case ItemBreakMode.Open:
@@ -40,7 +40,7 @@ public class RequestItemBreakHandler : GamePacketHandler
                 HandleAutoAdd(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RequestItemInventoryHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemInventoryHandler.cs
@@ -5,11 +5,11 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestItemInventoryHandler : GamePacketHandler
+internal sealed class RequestItemInventoryHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_ITEM_INVENTORY;
 
-    private static class RequestItemInventoryMode
+    private static class RequestItemInventoryOperations
     {
         public const byte Move = 0x3;
         public const byte Drop = 0x4;
@@ -20,27 +20,27 @@ public class RequestItemInventoryHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
-            case RequestItemInventoryMode.Move:
+            case RequestItemInventoryOperations.Move:
                 HandleMove(session, packet);
                 break;
-            case RequestItemInventoryMode.Drop:
+            case RequestItemInventoryOperations.Drop:
                 HandleDrop(session, packet);
                 break;
-            case RequestItemInventoryMode.DropBound:
+            case RequestItemInventoryOperations.DropBound:
                 HandleDropBound(session, packet);
                 break;
-            case RequestItemInventoryMode.Sort:
+            case RequestItemInventoryOperations.Sort:
                 HandleSort(session, packet);
                 break;
-            case RequestItemInventoryMode.Expand:
+            case RequestItemInventoryOperations.Expand:
                 HandleExpand(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RequestItemInventoryHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemInventoryHandler.cs
@@ -9,18 +9,18 @@ public class RequestItemInventoryHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_ITEM_INVENTORY;
 
-    private enum RequestItemInventoryMode : byte
+    private static class RequestItemInventoryMode
     {
-        Move = 0x3,
-        Drop = 0x4,
-        DropBound = 0x5,
-        Sort = 0xA,
-        Expand = 0xB
+        public const byte Move = 0x3;
+        public const byte Drop = 0x4;
+        public const byte DropBound = 0x5;
+        public const byte Sort = 0xA;
+        public const byte Expand = 0xB;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        RequestItemInventoryMode mode = (RequestItemInventoryMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
@@ -40,7 +40,7 @@ public class RequestItemInventoryHandler : GamePacketHandler
                 HandleExpand(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RequestItemLockHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemLockHandler.cs
@@ -4,11 +4,11 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestItemLockHandler : GamePacketHandler
+internal sealed class RequestItemLockHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_ITEM_LOCK;
 
-    private static class ItemLockMode
+    private static class ItemLockOperations
     {
         public const byte Open = 0x00;
         public const byte Add = 0x01;
@@ -18,23 +18,23 @@ public class RequestItemLockHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
-        switch (mode)
+        var operation = packet.ReadByte();
+        switch (operation)
         {
-            case ItemLockMode.Open:
+            case ItemLockOperations.Open:
                 session.Player.LockInventory = new();
                 break;
-            case ItemLockMode.Add:
+            case ItemLockOperations.Add:
                 HandleAdd(session, packet);
                 break;
-            case ItemLockMode.Remove:
+            case ItemLockOperations.Remove:
                 HandleRemove(session, packet);
                 break;
-            case ItemLockMode.Update:
+            case ItemLockOperations.Update:
                 HandleUpdateItem(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RequestItemLockHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemLockHandler.cs
@@ -8,17 +8,17 @@ public class RequestItemLockHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_ITEM_LOCK;
 
-    private enum ItemLockMode : byte
+    private static class ItemLockMode
     {
-        Open = 0x00,
-        Add = 0x01,
-        Remove = 0x02,
-        Update = 0x03
+        public const byte Open = 0x00;
+        public const byte Add = 0x01;
+        public const byte Remove = 0x02;
+        public const byte Update = 0x03;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ItemLockMode mode = (ItemLockMode) packet.ReadByte();
+        var mode = packet.ReadByte();
         switch (mode)
         {
             case ItemLockMode.Open:
@@ -34,7 +34,7 @@ public class RequestItemLockHandler : GamePacketHandler
                 HandleUpdateItem(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RequestItemPickupHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemPickupHandler.cs
@@ -6,7 +6,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestItemPickupHandler : GamePacketHandler
+internal sealed class RequestItemPickupHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_ITEM_PICKUP;
 

--- a/MapleServer2/PacketHandlers/Game/RequestItemStorage.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemStorage.cs
@@ -10,21 +10,21 @@ public class RequestItemStorage : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_ITEM_STORAGE;
 
-    private enum ItemStorageMode : byte
+    private static class ItemStorageMode
     {
-        Add = 0x00,
-        Remove = 0x01,
-        Move = 0x02,
-        Mesos = 0x03,
-        Expand = 0x06,
-        Sort = 0x08,
-        LoadBank = 0x0C,
-        Close = 0x0F
+        public const byte Add = 0x00;
+        public const byte Remove = 0x01;
+        public const byte Move = 0x02;
+        public const byte Mesos = 0x03;
+        public const byte Expand = 0x06;
+        public const byte Sort = 0x08;
+        public const byte LoadBank = 0x0C;
+        public const byte Close = 0x0F;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ItemStorageMode mode = (ItemStorageMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
@@ -53,7 +53,7 @@ public class RequestItemStorage : GamePacketHandler
                 HandleClose(session.Player.Account.BankInventory);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RequestItemStorage.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemStorage.cs
@@ -6,7 +6,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestItemStorage : GamePacketHandler
+internal sealed class RequestItemStorage : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_ITEM_STORAGE;
 
@@ -24,9 +24,9 @@ public class RequestItemStorage : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
             case ItemStorageMode.Add:
                 HandleAdd(session, packet);
@@ -53,7 +53,7 @@ public class RequestItemStorage : GamePacketHandler
                 HandleClose(session.Player.Account.BankInventory);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RequestItemUseHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemUseHandler.cs
@@ -15,7 +15,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestItemUseHandler : GamePacketHandler
+internal sealed class RequestItemUseHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_ITEM_USE;
 

--- a/MapleServer2/PacketHandlers/Game/RequestItemUseMultipleHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemUseMultipleHandler.cs
@@ -9,7 +9,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestItemUseMultipleHandler : GamePacketHandler
+internal sealed class RequestItemUseMultipleHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_ITEM_USE_MULTIPLE;
 

--- a/MapleServer2/PacketHandlers/Game/RequestItemUseMultipleHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemUseMultipleHandler.cs
@@ -13,10 +13,10 @@ public class RequestItemUseMultipleHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_ITEM_USE_MULTIPLE;
 
-    private enum BoxType : byte
+    private static class BoxType
     {
-        OPEN = 0x00,
-        SELECT = 0x01
+        public const byte Open = 0x00;
+        public const byte Select = 0x01;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
@@ -24,7 +24,7 @@ public class RequestItemUseMultipleHandler : GamePacketHandler
         int itemId = packet.ReadInt();
         packet.ReadShort(); // Unknown
         int amount = packet.ReadInt();
-        BoxType boxType = (BoxType) packet.ReadShort();
+        var boxType = packet.ReadShort();
 
         string functionName = ItemMetadataStorage.GetFunction(itemId).Name;
         if (functionName != "SelectItemBox" && functionName != "OpenItemBox")
@@ -39,7 +39,7 @@ public class RequestItemUseMultipleHandler : GamePacketHandler
         }
 
         int index = 0;
-        if (boxType == BoxType.SELECT)
+        if (boxType == BoxType.Select)
         {
             index = packet.ReadShort() - 0x30; // Starts at 0x30 for some reason
             if (index < 0)

--- a/MapleServer2/PacketHandlers/Game/RequestMoneyPickupHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestMoneyPickupHandler.cs
@@ -6,7 +6,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestMoneyPickupHandler : GamePacketHandler
+internal sealed class RequestMoneyPickupHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_MONEY_PICKUP;
 

--- a/MapleServer2/PacketHandlers/Game/RequestTaxiHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestTaxiHandler.cs
@@ -13,42 +13,42 @@ internal class RequestTaxiHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_TAXI;
 
-    private enum RequestTaxiMode : byte
+    private static class RequestTaxiOperation
     {
-        Car = 0x1,
-        RotorsMeso = 0x3,
-        RotorsMeret = 0x4,
-        DiscoverTaxi = 0x5
+        public const byte Car = 0x1;
+        public const byte RotorsMeso = 0x3;
+        public const byte RotorsMeret = 0x4;
+        public const byte DiscoverTaxi = 0x5;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        RequestTaxiMode mode = (RequestTaxiMode) packet.ReadByte();
+        var operation = packet.ReadByte();
 
         int mapId = 0;
         long meretPrice = 15;
 
-        if (mode != RequestTaxiMode.DiscoverTaxi)
+        if (operation != RequestTaxiOperation.DiscoverTaxi)
         {
             mapId = packet.ReadInt();
         }
 
-        switch (mode)
+        switch (operation)
         {
-            case RequestTaxiMode.Car:
+            case RequestTaxiOperation.Car:
                 HandleCarTaxi(session, mapId);
                 break;
-            case RequestTaxiMode.RotorsMeso:
+            case RequestTaxiOperation.RotorsMeso:
                 HandleRotorMeso(session, mapId);
                 break;
-            case RequestTaxiMode.RotorsMeret:
+            case RequestTaxiOperation.RotorsMeret:
                 HandleRotorMeret(session, mapId, meretPrice);
                 break;
-            case RequestTaxiMode.DiscoverTaxi:
+            case RequestTaxiOperation.DiscoverTaxi:
                 HandleDiscoverTaxi(session);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RequestTaxiHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestTaxiHandler.cs
@@ -9,7 +9,7 @@ using MoonSharp.Interpreter;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-internal class RequestTaxiHandler : GamePacketHandler
+internal sealed class RequestTaxiHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_TAXI;
 

--- a/MapleServer2/PacketHandlers/Game/RequestTimeSyncHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestTimeSyncHandler.cs
@@ -5,7 +5,7 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestTimeSyncHandler : GamePacketHandler
+internal sealed class RequestTimeSyncHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_TIME_SYNC;
 

--- a/MapleServer2/PacketHandlers/Game/RequestTutorialItemHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestTutorialItemHandler.cs
@@ -7,7 +7,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestTutorialItemHandler : GamePacketHandler
+internal sealed class RequestTutorialItemHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_TUTORIAL_ITEM;
 

--- a/MapleServer2/PacketHandlers/Game/RequestUserEnvHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestUserEnvHandler.cs
@@ -5,7 +5,7 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestUserEnvHandler : GamePacketHandler
+internal sealed class RequestUserEnvHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_USER_ENV;
 
@@ -17,9 +17,9 @@ public class RequestUserEnvHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
             case UserEnvMode.Change:
                 HandleTitleChange(session, packet);
@@ -28,7 +28,7 @@ public class RequestUserEnvHandler : GamePacketHandler
                 HandleTrophy(session);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RequestUserEnvHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestUserEnvHandler.cs
@@ -9,15 +9,15 @@ public class RequestUserEnvHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_USER_ENV;
 
-    private enum UserEnvMode : byte
+    private static class UserEnvMode
     {
-        Change = 0x1,
-        Trophy = 0x3
+        public const byte Change = 0x1;
+        public const byte Trophy = 0x3;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        UserEnvMode mode = (UserEnvMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
@@ -28,7 +28,7 @@ public class RequestUserEnvHandler : GamePacketHandler
                 HandleTrophy(session);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RequestWorldMapHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestWorldMapHandler.cs
@@ -5,14 +5,14 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RequestWorldMapHandler : GamePacketHandler
+internal sealed class RequestWorldMapHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_WORLD_MAP;
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        byte mode = packet.ReadByte();
-        switch (mode)
+        byte operation = packet.ReadByte();
+        switch (operation)
         {
             case 0: // open
                 HandleOpen(session);

--- a/MapleServer2/PacketHandlers/Game/RideHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RideHandler.cs
@@ -12,18 +12,18 @@ public class RideHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_RIDE;
 
-    private enum RideMode : byte
+    private static class RideMode
     {
-        StartRide = 0x0,
-        StopRide = 0x1,
-        ChangeRide = 0x2,
-        StartMultiPersonRide = 0x3,
-        StopMultiPersonRide = 0x4
+        public const byte StartRide = 0x0;
+        public const byte StopRide = 0x1;
+        public const byte ChangeRide = 0x2;
+        public const byte StartMultiPersonRide = 0x3;
+        public const byte StopMultiPersonRide = 0x4;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        RideMode mode = (RideMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
@@ -43,7 +43,7 @@ public class RideHandler : GamePacketHandler
                 HandleStopMultiPersonRide(session);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RideHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RideHandler.cs
@@ -8,11 +8,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RideHandler : GamePacketHandler
+internal sealed class RideHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_RIDE;
 
-    private static class RideMode
+    private static class RideOperations
     {
         public const byte StartRide = 0x0;
         public const byte StopRide = 0x1;
@@ -23,27 +23,27 @@ public class RideHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
-            case RideMode.StartRide:
+            case RideOperations.StartRide:
                 HandleStartRide(session, packet);
                 break;
-            case RideMode.StopRide:
+            case RideOperations.StopRide:
                 HandleStopRide(session, packet);
                 break;
-            case RideMode.ChangeRide:
+            case RideOperations.ChangeRide:
                 HandleChangeRide(session, packet);
                 break;
-            case RideMode.StartMultiPersonRide:
+            case RideOperations.StartMultiPersonRide:
                 HandleStartMultiPersonRide(session, packet);
                 break;
-            case RideMode.StopMultiPersonRide:
+            case RideOperations.StopMultiPersonRide:
                 HandleStopMultiPersonRide(session);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/RideSyncHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RideSyncHandler.cs
@@ -7,13 +7,13 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class RideSyncHandler : GamePacketHandler
+internal sealed class RideSyncHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.RIDE_SYNC;
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        byte function = packet.ReadByte(); // Unknown what this is for
+        byte operation = packet.ReadByte(); // Unknown what this is for
         packet.ReadInt(); // ServerTicks
         packet.ReadInt(); // ClientTicks
         byte segments = packet.ReadByte();

--- a/MapleServer2/PacketHandlers/Game/ShopHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ShopHandler.cs
@@ -15,17 +15,17 @@ public class ShopHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.SHOP;
 
-    private enum ShopMode : byte
+    private static class ShopMode
     {
-        Buy = 0x4,
-        Sell = 0x5,
-        Close = 0x6,
-        OpenViaItem = 0x0A
+        public const byte Buy = 0x4;
+        public const byte Sell = 0x5;
+        public const byte Close = 0x6;
+        public const byte OpenViaItem = 0x0A;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ShopMode mode = (ShopMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
@@ -42,7 +42,7 @@ public class ShopHandler : GamePacketHandler
                 HandleOpenViaItem(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/ShopHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ShopHandler.cs
@@ -11,11 +11,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class ShopHandler : GamePacketHandler
+internal sealed class ShopHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.SHOP;
 
-    private static class ShopMode
+    private static class ShopOperations
     {
         public const byte Buy = 0x4;
         public const byte Sell = 0x5;
@@ -25,24 +25,24 @@ public class ShopHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
-            case ShopMode.Close:
+            case ShopOperations.Close:
                 HandleClose(session);
                 break;
-            case ShopMode.Buy:
+            case ShopOperations.Buy:
                 HandleBuy(session, packet);
                 break;
-            case ShopMode.Sell:
+            case ShopOperations.Sell:
                 HandleSell(session, packet);
                 break;
-            case ShopMode.OpenViaItem:
+            case ShopOperations.OpenViaItem:
                 HandleOpenViaItem(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/SkillBookTreeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SkillBookTreeHandler.cs
@@ -11,17 +11,17 @@ public class SkillBookTreeHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_SKILL_BOOK_TREE;
 
-    private enum SkillBookMode : byte
+    private static class SkillBookMode
     {
-        Open = 0x00,
-        Save = 0x01,
-        Rename = 0x02,
-        AddTab = 0x04
+        public const byte Open = 0x00;
+        public const byte Save = 0x01;
+        public const byte Rename = 0x02;
+        public const byte AddTab = 0x04;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        SkillBookMode mode = (SkillBookMode) packet.ReadByte();
+        var mode = packet.ReadByte();
         switch (mode)
         {
             case SkillBookMode.Open:
@@ -37,7 +37,7 @@ public class SkillBookTreeHandler : GamePacketHandler
                 HandleAddTab(session);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/SkillBookTreeHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SkillBookTreeHandler.cs
@@ -7,11 +7,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class SkillBookTreeHandler : GamePacketHandler
+internal sealed class SkillBookTreeHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.REQUEST_SKILL_BOOK_TREE;
 
-    private static class SkillBookMode
+    private static class SkillBookOperations
     {
         public const byte Open = 0x00;
         public const byte Save = 0x01;
@@ -21,23 +21,23 @@ public class SkillBookTreeHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
-        switch (mode)
+        var operation = packet.ReadByte();
+        switch (operation)
         {
-            case SkillBookMode.Open:
+            case SkillBookOperations.Open:
                 HandleOpen(session);
                 break;
-            case SkillBookMode.Save:
+            case SkillBookOperations.Save:
                 HandleSave(session, packet);
                 break;
-            case SkillBookMode.Rename:
+            case SkillBookOperations.Rename:
                 HandleRename(session, packet);
                 break;
-            case SkillBookMode.AddTab:
+            case SkillBookOperations.AddTab:
                 HandleAddTab(session);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/SkillHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SkillHandler.cs
@@ -18,26 +18,26 @@ public class SkillHandler : GamePacketHandler
 
     public override RecvOp OpCode => RecvOp.SKILL;
 
-    private enum SkillHandlerMode : byte
+    private static class SkillHandlerMode
     {
-        Cast = 0x0,
-        Damage = 0x1,
-        Sync = 0x2,
-        SyncTick = 0x3,
-        Cancel = 0x4
+        public const byte Cast = 0x0;
+        public const byte Damage = 0x1;
+        public const byte Sync = 0x2;
+        public const byte SyncTick = 0x3;
+        public const byte Cancel = 0x4;
     }
 
-    private enum DamagingMode : byte
+    private static class DamagingMode
     {
-        SyncDamage = 0x0,
-        Damage = 0x1,
-        RegionSkill = 0x2
+        public const byte SyncDamage = 0x0;
+        public const byte Damage = 0x1;
+        public const byte RegionSkill = 0x2;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        SkillHandlerMode mode = (SkillHandlerMode) packet.ReadByte();
-        switch (mode)
+        var operation = packet.ReadByte();
+        switch (operation)
         {
             case SkillHandlerMode.Cast:
                 HandleCast(session, packet);
@@ -55,15 +55,15 @@ public class SkillHandler : GamePacketHandler
                 HandleCancelSkill(packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }
 
-    private static void HandleDamageMode(GameSession session, PacketReader packet)
+    private void HandleDamageMode(GameSession session, PacketReader packet)
     {
-        DamagingMode mode = (DamagingMode) packet.ReadByte();
-        switch (mode)
+        var operation = packet.ReadByte();
+        switch (operation)
         {
             case DamagingMode.SyncDamage:
                 HandleSyncDamage(session, packet);
@@ -75,7 +75,7 @@ public class SkillHandler : GamePacketHandler
                 HandleRegionSkills(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/SkillHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SkillHandler.cs
@@ -12,13 +12,13 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class SkillHandler : GamePacketHandler
+internal sealed class SkillHandler : GamePacketHandler
 {
     private static readonly Random Rand = RandomProvider.Get();
 
     public override RecvOp OpCode => RecvOp.SKILL;
 
-    private static class SkillHandlerMode
+    private static class SkillHandlerOperations
     {
         public const byte Cast = 0x0;
         public const byte Damage = 0x1;
@@ -27,7 +27,7 @@ public class SkillHandler : GamePacketHandler
         public const byte Cancel = 0x4;
     }
 
-    private static class DamagingMode
+    private static class DamagingOperation
     {
         public const byte SyncDamage = 0x0;
         public const byte Damage = 0x1;
@@ -39,19 +39,19 @@ public class SkillHandler : GamePacketHandler
         var operation = packet.ReadByte();
         switch (operation)
         {
-            case SkillHandlerMode.Cast:
+            case SkillHandlerOperations.Cast:
                 HandleCast(session, packet);
                 break;
-            case SkillHandlerMode.Damage:
+            case SkillHandlerOperations.Damage:
                 HandleDamageMode(session, packet);
                 break;
-            case SkillHandlerMode.Sync:
+            case SkillHandlerOperations.Sync:
                 HandleSyncSkills(session, packet);
                 break;
-            case SkillHandlerMode.SyncTick:
+            case SkillHandlerOperations.SyncTick:
                 HandleSyncTick(packet);
                 break;
-            case SkillHandlerMode.Cancel:
+            case SkillHandlerOperations.Cancel:
                 HandleCancelSkill(packet);
                 break;
             default:
@@ -65,13 +65,13 @@ public class SkillHandler : GamePacketHandler
         var operation = packet.ReadByte();
         switch (operation)
         {
-            case DamagingMode.SyncDamage:
+            case DamagingOperation.SyncDamage:
                 HandleSyncDamage(session, packet);
                 break;
-            case DamagingMode.Damage:
+            case DamagingOperation.Damage:
                 HandleDamage(session, packet);
                 break;
-            case DamagingMode.RegionSkill:
+            case DamagingOperation.RegionSkill:
                 HandleRegionSkills(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
@@ -6,11 +6,11 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class StatPointHandler : GamePacketHandler
+internal sealed class StatPointHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.STAT_POINT;
 
-    private static class StatPointMode
+    private static class StatPointOperations
     {
         public const byte Increment = 0x2;
         public const byte Reset = 0x3;
@@ -18,18 +18,18 @@ public class StatPointHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
-            case StatPointMode.Increment:
+            case StatPointOperations.Increment:
                 HandleStatIncrement(session, packet);
                 break;
-            case StatPointMode.Reset:
+            case StatPointOperations.Reset:
                 HandleResetStatDistribution(session);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/StatPointHandler.cs
@@ -10,15 +10,15 @@ public class StatPointHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.STAT_POINT;
 
-    private enum StatPointMode : byte
+    private static class StatPointMode
     {
-        Increment = 0x2,
-        Reset = 0x3
+        public const byte Increment = 0x2;
+        public const byte Reset = 0x3;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        StatPointMode mode = (StatPointMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
@@ -29,7 +29,7 @@ public class StatPointHandler : GamePacketHandler
                 HandleResetStatDistribution(session);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/StateHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/StateHandler.cs
@@ -8,15 +8,15 @@ public class StateHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.STATE;
 
-    private enum StateHandlerMode : byte
+    private static class StateHandlerMode
     {
-        Jump = 0x0,
-        Land = 0x1
+        public const byte Jump = 0x0;
+        public const byte Land = 0x1;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        StateHandlerMode mode = (StateHandlerMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {

--- a/MapleServer2/PacketHandlers/Game/StateHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/StateHandler.cs
@@ -4,11 +4,11 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class StateHandler : GamePacketHandler
+internal sealed class StateHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.STATE;
 
-    private static class StateHandlerMode
+    private static class StateHandlerOperations
     {
         public const byte Jump = 0x0;
         public const byte Land = 0x1;
@@ -20,10 +20,10 @@ public class StateHandler : GamePacketHandler
 
         switch (mode)
         {
-            case StateHandlerMode.Jump:
+            case StateHandlerOperations.Jump:
                 HandleJump(session);
                 break;
-            case StateHandlerMode.Land:
+            case StateHandlerOperations.Land:
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/StateSkillHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/StateSkillHandler.cs
@@ -11,8 +11,8 @@ public class StateSkillHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        byte function = packet.ReadByte();
-        if (function == 0)
+        byte operation = packet.ReadByte();
+        if (operation == 0)
         {
             // This count seems to increase for each skill used
             int counter = packet.ReadInt();

--- a/MapleServer2/PacketHandlers/Game/StateSkillHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/StateSkillHandler.cs
@@ -5,7 +5,7 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class StateSkillHandler : GamePacketHandler
+internal sealed class StateSkillHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.STATE_SKILL;
 

--- a/MapleServer2/PacketHandlers/Game/SuperChatHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SuperChatHandler.cs
@@ -10,15 +10,15 @@ public class SuperChatHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.SUPER_WORLDCHAT;
 
-    private enum SuperChatMode : byte
+    private static class SuperChatMode
     {
-        Select = 0x0,
-        Deselect = 0x1
+        public const byte Select = 0x0;
+        public const byte Deselect = 0x1;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        SuperChatMode mode = (SuperChatMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
@@ -29,7 +29,7 @@ public class SuperChatHandler : GamePacketHandler
                 HandleDeselect(session);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/SuperChatHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SuperChatHandler.cs
@@ -6,11 +6,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class SuperChatHandler : GamePacketHandler
+internal sealed class SuperChatHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.SUPER_WORLDCHAT;
 
-    private static class SuperChatMode
+    private static class SuperChatOperations
     {
         public const byte Select = 0x0;
         public const byte Deselect = 0x1;
@@ -22,10 +22,10 @@ public class SuperChatHandler : GamePacketHandler
 
         switch (mode)
         {
-            case SuperChatMode.Select:
+            case SuperChatOperations.Select:
                 HandleSelect(session, packet);
                 break;
-            case SuperChatMode.Deselect:
+            case SuperChatOperations.Deselect:
                 HandleDeselect(session);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/SystemShopHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SystemShopHandler.cs
@@ -8,11 +8,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class SystemShopHandler : GamePacketHandler
+internal sealed class SystemShopHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.SYSTEM_SHOP;
 
-    private static class ShopMode
+    private static class ShopOperations
     {
         public const byte Arena = 0x03;
         public const byte Fishing = 0x04;
@@ -25,13 +25,13 @@ public class SystemShopHandler : GamePacketHandler
 
         switch (mode)
         {
-            case ShopMode.ViaItem:
+            case ShopOperations.ViaItem:
                 HandleViaItem(session, packet);
                 break;
-            case ShopMode.Fishing:
+            case ShopOperations.Fishing:
                 HandleFishingShop(session, packet);
                 break;
-            case ShopMode.Arena:
+            case ShopOperations.Arena:
                 HandleMapleArenaShop(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/SystemShopHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SystemShopHandler.cs
@@ -12,16 +12,16 @@ public class SystemShopHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.SYSTEM_SHOP;
 
-    private enum ShopMode : byte
+    private static class ShopMode
     {
-        Arena = 0x03,
-        Fishing = 0x04,
-        ViaItem = 0x0A
+        public const byte Arena = 0x03;
+        public const byte Fishing = 0x04;
+        public const byte ViaItem = 0x0A;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        ShopMode mode = (ShopMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
@@ -35,7 +35,7 @@ public class SystemShopHandler : GamePacketHandler
                 HandleMapleArenaShop(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/TriggerHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/TriggerHandler.cs
@@ -7,11 +7,11 @@ using static MapleServer2.Packets.TriggerPacket;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class TriggerHandler : GamePacketHandler
+internal sealed class TriggerHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.TRIGGER;
 
-    private static class TriggerMode
+    private static class TriggerOperations
     {
         public const byte SkipCutscene = 0x7;
         public const byte UpdateWidget = 0x8;
@@ -19,18 +19,18 @@ public class TriggerHandler : GamePacketHandler
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
+        var operation = packet.ReadByte();
 
-        switch (mode)
+        switch (operation)
         {
-            case TriggerMode.SkipCutscene:
+            case TriggerOperations.SkipCutscene:
                 HandleSkipCutscene(session);
                 break;
-            case TriggerMode.UpdateWidget:
+            case TriggerOperations.UpdateWidget:
                 HandleUpdateWidget(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/TriggerHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/TriggerHandler.cs
@@ -11,15 +11,15 @@ public class TriggerHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.TRIGGER;
 
-    private enum TriggerMode : byte
+    private static class TriggerMode
     {
-        SkipCutscene = 0x7,
-        UpdateWidget = 0x8
+        public const byte SkipCutscene = 0x7;
+        public const byte UpdateWidget = 0x8;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        TriggerMode mode = (TriggerMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
@@ -30,7 +30,7 @@ public class TriggerHandler : GamePacketHandler
                 HandleUpdateWidget(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/TrophyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/TrophyHandler.cs
@@ -14,15 +14,15 @@ public class TrophyHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.TROPHY;
 
-    private enum TrophyHandlerMode : byte
+    private static class TrophyHandlerMode
     {
-        ClaimReward = 0x03,
-        Favorite = 0x04
+        public const byte ClaimReward = 0x03;
+        public const byte Favorite = 0x04;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        TrophyHandlerMode mode = (TrophyHandlerMode) packet.ReadByte();
+        var mode = packet.ReadByte();
 
         switch (mode)
         {
@@ -33,7 +33,7 @@ public class TrophyHandler : GamePacketHandler
                 HandleFavorite(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(mode);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/TrophyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/TrophyHandler.cs
@@ -10,11 +10,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class TrophyHandler : GamePacketHandler
+internal sealed class TrophyHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.TROPHY;
 
-    private static class TrophyHandlerMode
+    private static class TrophyHandlerOperations
     {
         public const byte ClaimReward = 0x03;
         public const byte Favorite = 0x04;
@@ -26,10 +26,10 @@ public class TrophyHandler : GamePacketHandler
 
         switch (mode)
         {
-            case TrophyHandlerMode.ClaimReward:
+            case TrophyHandlerOperations.ClaimReward:
                 HandleClaimReward(session, packet);
                 break;
-            case TrophyHandlerMode.Favorite:
+            case TrophyHandlerOperations.Favorite:
                 HandleFavorite(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/TutorialHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/TutorialHandler.cs
@@ -6,7 +6,7 @@ using MapleServer2.Servers.Game;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class TutorialHandler : GamePacketHandler
+internal sealed class TutorialHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.TUTORIAL;
 

--- a/MapleServer2/PacketHandlers/Game/UgcHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/UgcHandler.cs
@@ -10,11 +10,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class UgcHandler : GamePacketHandler
+internal sealed class UgcHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.UGC;
 
-    private static class UgcMode
+    private static class UgcOperations
     {
         public const byte CreateUgcItem = 0x01;
         public const byte AddUgcItem = 0x03;
@@ -26,13 +26,13 @@ public class UgcHandler : GamePacketHandler
         var operation = packet.ReadByte();
         switch (operation)
         {
-            case UgcMode.CreateUgcItem:
+            case UgcOperations.CreateUgcItem:
                 HandleCreateUGCItem(session, packet);
                 break;
-            case UgcMode.AddUgcItem:
+            case UgcOperations.AddUgcItem:
                 HandleAddUgcItem(session, packet);
                 break;
-            case UgcMode.ProfilePicture:
+            case UgcOperations.ProfilePicture:
                 HandleProfilePicture(session, packet);
                 break;
             default:

--- a/MapleServer2/PacketHandlers/Game/UgcHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/UgcHandler.cs
@@ -14,17 +14,17 @@ public class UgcHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.UGC;
 
-    private enum UgcMode : byte
+    private static class UgcMode
     {
-        CreateUgcItem = 0x01,
-        AddUgcItem = 0x03,
-        ProfilePicture = 0x0B
+        public const byte CreateUgcItem = 0x01;
+        public const byte AddUgcItem = 0x03;
+        public const byte ProfilePicture = 0x0B;
     }
 
     public override void Handle(GameSession session, PacketReader packet)
     {
-        UgcMode function = (UgcMode) packet.ReadByte();
-        switch (function)
+        var operation = packet.ReadByte();
+        switch (operation)
         {
             case UgcMode.CreateUgcItem:
                 HandleCreateUGCItem(session, packet);
@@ -36,7 +36,7 @@ public class UgcHandler : GamePacketHandler
                 HandleProfilePicture(session, packet);
                 break;
             default:
-                IPacketHandler<GameSession>.LogUnknownMode(function);
+                IPacketHandler<GameSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Game/UserChatHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/UserChatHandler.cs
@@ -12,7 +12,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class UserChatHandler : GamePacketHandler
+internal sealed class UserChatHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.USER_CHAT;
 

--- a/MapleServer2/PacketHandlers/Game/UserSyncHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/UserSyncHandler.cs
@@ -11,7 +11,7 @@ namespace MapleServer2.PacketHandlers.Game;
 
 // ClientTicks/Time here are probably used for animation
 // Currently I am just updating animation instantly.
-public class UserSyncHandler : GamePacketHandler
+internal sealed class UserSyncHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.USER_SYNC;
 

--- a/MapleServer2/PacketHandlers/Game/VibrateHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/VibrateHandler.cs
@@ -8,7 +8,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Game;
 
-public class VibrateHandler : GamePacketHandler
+internal sealed class VibrateHandler : GamePacketHandler
 {
     public override RecvOp OpCode => RecvOp.VIBRATE;
 

--- a/MapleServer2/PacketHandlers/IPacketHandler.cs
+++ b/MapleServer2/PacketHandlers/IPacketHandler.cs
@@ -17,4 +17,9 @@ public interface IPacketHandler<in T> where T : Session
     {
         LogManager.GetCurrentClassLogger().Warn("New Unknown " + mode.GetType().Name + ": 0x" + mode.ToString("X"));
     }
+
+    public static void LogUnknownMode(Type packetHandlerType, byte mode)
+    {
+        LogManager.GetCurrentClassLogger().Warn($"Unknown mode in {packetHandlerType}: 0x{mode.ToString("X")}");
+    }
 }

--- a/MapleServer2/PacketHandlers/Login/CharacterManagementHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/CharacterManagementHandler.cs
@@ -16,16 +16,16 @@ public class CharacterManagementHandler : LoginPacketHandler
 {
     public override RecvOp OpCode => RecvOp.CHARACTER_MANAGEMENT;
 
-    private enum CharacterManagementMode : byte
+    private static class CharacterManagementMode
     {
-        Login = 0x0,
-        Create = 0x1,
-        Delete = 0x2
+        public const byte Login = 0x0;
+        public const byte Create = 0x1;
+        public const byte Delete = 0x2;
     }
 
     public override void Handle(LoginSession session, PacketReader packet)
     {
-        CharacterManagementMode mode = (CharacterManagementMode) packet.ReadByte();
+        var mode = packet.ReadByte();
         switch (mode)
         {
             case CharacterManagementMode.Login:
@@ -38,7 +38,7 @@ public class CharacterManagementHandler : LoginPacketHandler
                 HandleDelete(session, packet);
                 break;
             default:
-                IPacketHandler<LoginSession>.LogUnknownMode(mode);
+                IPacketHandler<LoginSession>.LogUnknownMode(GetType(), mode);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Login/CharacterManagementHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/CharacterManagementHandler.cs
@@ -12,11 +12,11 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Login;
 
-public class CharacterManagementHandler : LoginPacketHandler
+internal sealed class CharacterManagementHandler : LoginPacketHandler
 {
     public override RecvOp OpCode => RecvOp.CHARACTER_MANAGEMENT;
 
-    private static class CharacterManagementMode
+    private static class CharacterManagementOperations
     {
         public const byte Login = 0x0;
         public const byte Create = 0x1;
@@ -25,20 +25,20 @@ public class CharacterManagementHandler : LoginPacketHandler
 
     public override void Handle(LoginSession session, PacketReader packet)
     {
-        var mode = packet.ReadByte();
-        switch (mode)
+        var operation = packet.ReadByte();
+        switch (operation)
         {
-            case CharacterManagementMode.Login:
+            case CharacterManagementOperations.Login:
                 HandleSelect(session, packet);
                 break;
-            case CharacterManagementMode.Create:
+            case CharacterManagementOperations.Create:
                 HandleCreate(session, packet);
                 break;
-            case CharacterManagementMode.Delete:
+            case CharacterManagementOperations.Delete:
                 HandleDelete(session, packet);
                 break;
             default:
-                IPacketHandler<LoginSession>.LogUnknownMode(GetType(), mode);
+                IPacketHandler<LoginSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Login/LoginHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/LoginHandler.cs
@@ -13,7 +13,7 @@ using MapleServer2.Types;
 namespace MapleServer2.PacketHandlers.Login;
 
 // ReSharper disable once ClassNeverInstantiated.Global
-public class LoginHandler : LoginPacketHandler
+internal sealed class LoginHandler : LoginPacketHandler
 {
     public override RecvOp OpCode => RecvOp.RESPONSE_LOGIN;
 
@@ -21,7 +21,7 @@ public class LoginHandler : LoginPacketHandler
     private readonly ImmutableList<IPEndPoint> ServerIPs;
     private readonly string ServerName;
 
-    private static class LoginMode
+    private static class LoginOperations
     {
         public const byte Banners = 0x01;
         public const byte SendCharacters = 0x02;
@@ -81,10 +81,10 @@ public class LoginHandler : LoginPacketHandler
 
         switch (mode)
         {
-            case LoginMode.Banners:
+            case LoginOperations.Banners:
                 SendBanners(session, account);
                 break;
-            case LoginMode.SendCharacters:
+            case LoginOperations.SendCharacters:
                 SendCharacters(session, account);
                 break;
         }

--- a/MapleServer2/PacketHandlers/Login/LoginHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/LoginHandler.cs
@@ -21,10 +21,10 @@ public class LoginHandler : LoginPacketHandler
     private readonly ImmutableList<IPEndPoint> ServerIPs;
     private readonly string ServerName;
 
-    private enum LoginMode : byte
+    private static class LoginMode
     {
-        Banners = 0x01,
-        SendCharacters = 0x02
+        public const byte Banners = 0x01;
+        public const byte SendCharacters = 0x02;
     }
 
     public LoginHandler()
@@ -40,7 +40,7 @@ public class LoginHandler : LoginPacketHandler
 
     public override void Handle(LoginSession session, PacketReader packet)
     {
-        LoginMode mode = (LoginMode) packet.ReadByte();
+        var mode = packet.ReadByte();
         string username = packet.ReadUnicodeString();
         string password = packet.ReadUnicodeString();
 

--- a/MapleServer2/PacketHandlers/Login/LoginPacketHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/LoginPacketHandler.cs
@@ -5,7 +5,7 @@ using NLog;
 
 namespace MapleServer2.PacketHandlers.Login;
 
-public abstract class LoginPacketHandler : IPacketHandler<LoginSession>
+internal abstract class LoginPacketHandler : IPacketHandler<LoginSession>
 {
     public abstract RecvOp OpCode { get; }
 

--- a/MapleServer2/PacketHandlers/Login/LoginUgcHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/LoginUgcHandler.cs
@@ -6,25 +6,25 @@ using MapleServer2.Servers.Login;
 
 namespace MapleServer2.PacketHandlers.Login;
 
-public class LoginUgcHandler : LoginPacketHandler
+internal sealed class LoginUgcHandler : LoginPacketHandler
 {
     public override RecvOp OpCode => RecvOp.UGC;
 
-    private static class UgcMode
+    private static class UgcOperations
     {
         public const byte ProfilePicture = 0x0B;
     }
 
     public override void Handle(LoginSession session, PacketReader packet)
     {
-        var function = packet.ReadByte();
-        switch (function)
+        var operation = packet.ReadByte();
+        switch (operation)
         {
-            case UgcMode.ProfilePicture:
+            case UgcOperations.ProfilePicture:
                 HandleProfilePicture(session, packet);
                 break;
             default:
-                IPacketHandler<LoginSession>.LogUnknownMode(GetType(), function);
+                IPacketHandler<LoginSession>.LogUnknownMode(GetType(), operation);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Login/LoginUgcHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/LoginUgcHandler.cs
@@ -10,21 +10,21 @@ public class LoginUgcHandler : LoginPacketHandler
 {
     public override RecvOp OpCode => RecvOp.UGC;
 
-    private enum UgcMode : byte
+    private static class UgcMode
     {
-        ProfilePicture = 0x0B
+        public const byte ProfilePicture = 0x0B;
     }
 
     public override void Handle(LoginSession session, PacketReader packet)
     {
-        UgcMode function = (UgcMode) packet.ReadByte();
+        var function = packet.ReadByte();
         switch (function)
         {
             case UgcMode.ProfilePicture:
                 HandleProfilePicture(session, packet);
                 break;
             default:
-                IPacketHandler<LoginSession>.LogUnknownMode(function);
+                IPacketHandler<LoginSession>.LogUnknownMode(GetType(), function);
                 break;
         }
     }

--- a/MapleServer2/PacketHandlers/Login/ServerEnterPacketHandler.cs
+++ b/MapleServer2/PacketHandlers/Login/ServerEnterPacketHandler.cs
@@ -10,7 +10,7 @@ using MapleServer2.Types;
 
 namespace MapleServer2.PacketHandlers.Login;
 
-public class ServerEnterPacketHandler : LoginPacketHandler
+internal sealed class ServerEnterPacketHandler : LoginPacketHandler
 {
     public override RecvOp OpCode => RecvOp.RESPONSE_SERVER_ENTER;
 

--- a/MapleServer2/Packets/BuildModePacket.cs
+++ b/MapleServer2/Packets/BuildModePacket.cs
@@ -7,7 +7,7 @@ namespace MapleServer2.Packets;
 
 public static class BuildModePacket
 {
-    public static PacketWriter Use(IFieldObject<Player> fieldPlayer, BuildModeHandler.BuildModeType type, int itemId = 0, long itemUid = 0)
+    public static PacketWriter Use(IFieldObject<Player> fieldPlayer, byte type, int itemId = 0, long itemUid = 0)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.SET_BUILD_MODE);
         pWriter.WriteInt(fieldPlayer.ObjectId);
@@ -22,6 +22,7 @@ public static class BuildModePacket
                 pWriter.WriteByte();
                 pWriter.WriteInt();
                 break;
+            
             case BuildModeHandler.BuildModeType.Liftables:
                 pWriter.WriteInt(itemId);
                 pWriter.WriteLong();

--- a/MapleServer2/Packets/BuildModePacket.cs
+++ b/MapleServer2/Packets/BuildModePacket.cs
@@ -15,7 +15,7 @@ public static class BuildModePacket
 
         switch (type)
         {
-            case BuildModeHandler.BuildModeType.House:
+            case BuildModeHandler.BuildModeTypes.House:
                 pWriter.WriteInt(itemId);
                 pWriter.WriteLong(itemUid);
                 pWriter.WriteLong();
@@ -23,7 +23,7 @@ public static class BuildModePacket
                 pWriter.WriteInt();
                 break;
             
-            case BuildModeHandler.BuildModeType.Liftables:
+            case BuildModeHandler.BuildModeTypes.Liftables:
                 pWriter.WriteInt(itemId);
                 pWriter.WriteLong();
                 pWriter.WriteLong();


### PR DESCRIPTION
- Makes Packet Handlers `internal` and `sealed`, to prevent more inheritance mess
  - This inheritance nest needs to be unpicked eventually
- Replaces enums with classes containing constants in Packet Handlers
  - I think this is a bad habit that stems from early server emulators being written in Java, and those who started branching out to C# didn't realise that our `enum`s are not equivalent, and so they are used everywhere. The closest equivalent we have in C# is a `class`, although they don't translate very well still. There are always tons of unsafe operations happening with these enum types, and unnecessary casting as a result.