### PR TITLE
Make Items private, add new methods, remove other references

### DIFF
--- a/MapleServer2/Database/Classes/DatabaseInventory.cs
+++ b/MapleServer2/Database/Classes/DatabaseInventory.cs
@@ -30,7 +30,7 @@ public class DatabaseInventory : DatabaseTable
         });
 
         List<Item> items = new();
-        items.AddRange(inventory.Items.Values.Where(x => x != null).ToList());
+        items.AddRange(inventory.GetItemsNotNull().ToList());
         items.AddRange(inventory.Equips.Values.Where(x => x != null).ToList());
         items.AddRange(inventory.Badges.Where(x => x != null).ToList());
         items.AddRange(inventory.Cosmetics.Values.Where(x => x != null).ToList());

--- a/MapleServer2/Managers/ScriptManager.cs
+++ b/MapleServer2/Managers/ScriptManager.cs
@@ -22,7 +22,7 @@ public class ScriptManager
 
     public int GetItemCount(int itemId)
     {
-        return Player.Inventory.Items.Values.Where(x => x.Id == itemId).Sum(x => x.Amount);
+        return Player.Inventory.GetItemAmount(itemId);
     }
 
     public bool CanHold(int itemId, int amount)

--- a/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BeautyHandler.cs
@@ -452,7 +452,8 @@ internal sealed class BeautyHandler : GamePacketHandler
         long itemUid = packet.ReadLong();
 
         Player player = session.Player;
-        Item voucher = player.Inventory.Items[itemUid];
+        var inventory = player.Inventory;
+        Item voucher = inventory.GetItemByUid(itemUid);
         if (voucher == null || voucher.Function.Name != "ItemChangeBeauty")
         {
             return;
@@ -529,7 +530,7 @@ internal sealed class BeautyHandler : GamePacketHandler
 
     private static bool PayWithVoucher(GameSession session, BeautyMetadata shop)
     {
-        string voucherTag = ""; // using an Item's tag to search for any applicable voucher
+        string voucherTag; // using an Item's tag to search for any applicable voucher
         switch (shop.BeautyType)
         {
             case BeautyShopType.Hair:
@@ -557,7 +558,8 @@ internal sealed class BeautyHandler : GamePacketHandler
                 return false;
         }
 
-        Item voucher = session.Player.Inventory.Items.FirstOrDefault(x => x.Value.Tag == voucherTag).Value;
+        var inventory = session.Player.Inventory;
+        Item voucher = inventory.GetItemByTag(voucherTag);
         if (voucher == null)
         {
             session.Send(NoticePacket.Notice(SystemNotice.ItemNotFound, NoticeType.FastText));
@@ -606,7 +608,8 @@ internal sealed class BeautyHandler : GamePacketHandler
             case ShopCurrencyType.EventMeret:
                 return session.Player.Account.RemoveMerets(tokenCost);
             case ShopCurrencyType.Item:
-                Item itemCost = session.Player.Inventory.Items.FirstOrDefault(x => x.Value.Id == requiredItemId).Value;
+                var inventory = session.Player.Inventory;
+                Item itemCost = inventory.GetItemByItemId(requiredItemId);
                 if (itemCost == null)
                 {
                     return false;

--- a/MapleServer2/PacketHandlers/Game/BlackMarketHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/BlackMarketHandler.cs
@@ -81,7 +81,8 @@ internal sealed class BlackMarketHandler : GamePacketHandler
         int itemId = packet.ReadInt();
         int rarity = packet.ReadInt();
 
-        if (!session.Player.Inventory.Items.Any(x => x.Value.Id == itemId && x.Value.Rarity == rarity))
+        var inventory = session.Player.Inventory;
+        if (!inventory.HasItemWithRarity(itemId, rarity))
         {
             return;
         }
@@ -103,7 +104,8 @@ internal sealed class BlackMarketHandler : GamePacketHandler
         long price = packet.ReadLong();
         int quantity = packet.ReadInt();
 
-        if (!session.Player.Inventory.Items.ContainsKey(itemUid))
+        var inventory = session.Player.Inventory;
+        if (!inventory.HasItemWithUid(itemUid))
         {
             session.Send(BlackMarketPacket.Error(BlackMarketErrors.ItemNotInInventory));
             return;
@@ -120,7 +122,7 @@ internal sealed class BlackMarketHandler : GamePacketHandler
             return;
         }
 
-        Item item = session.Player.Inventory.Items[itemUid];
+        var item = inventory.GetItemByUid(itemUid);
         if (item.Amount < quantity)
         {
             return;

--- a/MapleServer2/PacketHandlers/Game/CardReverseGameHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/CardReverseGameHandler.cs
@@ -49,7 +49,8 @@ internal sealed class CardReverseGameHandler : GamePacketHandler
 
     private static void HandleMix(GameSession session)
     {
-        Item token = session.Player.Inventory.Items.FirstOrDefault(x => x.Value.Id == CardReverseGame.TOKEN_ITEM_ID).Value;
+        var inventory = session.Player.Inventory;
+        var token = inventory.GetItemByItemId(CardReverseGame.TOKEN_ITEM_ID);
         if (token == null || token.Amount < CardReverseGame.TOKEN_COST)
         {
             session.Send(CardReverseGamePacket.Notice());

--- a/MapleServer2/PacketHandlers/Game/ChangeAttributesScrollHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ChangeAttributesScrollHandler.cs
@@ -47,9 +47,9 @@ internal sealed class ChangeAttributesScrollHandler : GamePacketHandler
             lockStatId = packet.ReadShort();
         }
 
-        Inventory inventory = session.Player.Inventory;
-        Item scroll = inventory.Items.FirstOrDefault(x => x.Key == scrollUid).Value;
-        Item gear = inventory.Items.FirstOrDefault(x => x.Key == gearUid).Value;
+        var inventory = session.Player.Inventory;
+        Item scroll = inventory.GetItemByUid(scrollUid);
+        Item gear = inventory.GetItemByUid(gearUid);
         Item scrollLock = null;
 
         // Check if gear and scroll exists in inventory
@@ -78,7 +78,7 @@ internal sealed class ChangeAttributesScrollHandler : GamePacketHandler
 
         if (useLock)
         {
-            scrollLock = inventory.Items.FirstOrDefault(x => x.Value.Tag == tag && x.Value.Rarity == gear.Rarity).Value;
+            scrollLock = inventory.GetItemByTagAndRarity(tag, gear.Rarity);
             // Check if scroll lock exists in inventory
             if (scrollLock == null)
             {

--- a/MapleServer2/PacketHandlers/Game/EmoteHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/EmoteHandler.cs
@@ -38,12 +38,13 @@ internal sealed class EmoteHandler : GamePacketHandler
     {
         long itemUid = packet.ReadLong();
 
-        if (!session.Player.Inventory.Items.ContainsKey(itemUid))
+        var inventory = session.Player.Inventory;
+        if (!inventory.HasItemWithUid(itemUid))
         {
             return;
         }
 
-        Item item = session.Player.Inventory.Items[itemUid];
+        Item item = inventory.GetItemByUid(itemUid);
 
         if (session.Player.Emotes.Contains(item.SkillId))
         {

--- a/MapleServer2/PacketHandlers/Game/FishingHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/FishingHandler.cs
@@ -68,22 +68,23 @@ internal sealed class FishingHandler : GamePacketHandler
 
         if (!FishingSpotMetadataStorage.CanFish(session.Player.MapId, masteryExp.CurrentExp))
         {
-            session.Send(FishingPacket.Notice((short) FishingNotices.MasteryTooLowForMap));
+            session.Send(FishingPacket.Notice(FishingNotices.MasteryTooLowForMap));
             return;
         }
 
-        if (!session.Player.Inventory.Items.ContainsKey(fishingRodUid))
+        var inventory = session.Player.Inventory;
+        if (!inventory.HasItemWithUid(fishingRodUid))
         {
-            session.Send(FishingPacket.Notice((short) FishingNotices.InvalidFishingRod));
+            session.Send(FishingPacket.Notice(FishingNotices.InvalidFishingRod));
             return;
         }
 
-        Item fishingRod = session.Player.Inventory.Items[fishingRodUid];
+        Item fishingRod = inventory.GetItemByUid(fishingRodUid);
         FishingRodMetadata rodMetadata = FishingRodMetadataStorage.GetMetadata(fishingRod.Function.Id);
 
         if (rodMetadata.MasteryLimit < masteryExp.CurrentExp)
         {
-            session.Send(FishingPacket.Notice((short) FishingNotices.MasteryTooLowForRod));
+            session.Send(FishingPacket.Notice(FishingNotices.MasteryTooLowForRod));
         }
 
         int direction = Direction.GetClosestDirection(session.Player.FieldPlayer.Rotation);
@@ -92,7 +93,7 @@ internal sealed class FishingHandler : GamePacketHandler
         List<MapBlock> fishingBlocks = CollectFishingBlocks(startCoord, direction, session.Player.MapId);
         if (fishingBlocks.Count == 0)
         {
-            session.Send(FishingPacket.Notice((short) FishingNotices.CanOnlyFishNearWater));
+            session.Send(FishingPacket.Notice(FishingNotices.CanOnlyFishNearWater));
             return;
         }
         session.Player.FishingRod = fishingRod;

--- a/MapleServer2/PacketHandlers/Game/Helpers/ItemBoxHelper.cs
+++ b/MapleServer2/PacketHandlers/Game/Helpers/ItemBoxHelper.cs
@@ -109,7 +109,7 @@ internal static class ItemBoxHelper
         Inventory inventory = session.Player.Inventory;
         if (box.RequiredItemId > 0)
         {
-            Item requiredItem = inventory.Items[box.RequiredItemId];
+            var requiredItem = inventory.GetItemByItemId(box.RequiredItemId);
             if (requiredItem == null)
             {
                 return;

--- a/MapleServer2/PacketHandlers/Game/ItemEnchantHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemEnchantHandler.cs
@@ -35,7 +35,9 @@ internal sealed class ItemEnchantHandler : GamePacketHandler
         byte type = packet.ReadByte();
         long itemUid = packet.ReadLong();
 
-        if (session.Player.Inventory.Items.TryGetValue(itemUid, out Item item))
+        var inventory = session.Player.Inventory;
+        var item = inventory.GetItemByUid(itemUid);
+        if (item != null)
         {
             session.Send(ItemEnchantPacket.BeginEnchant(type, item));
         }
@@ -45,7 +47,9 @@ internal sealed class ItemEnchantHandler : GamePacketHandler
     {
         long itemUid = packet.ReadLong();
 
-        if (session.Player.Inventory.Items.TryGetValue(itemUid, out Item item))
+        var inventory = session.Player.Inventory;
+        var item = inventory.GetItemByUid(itemUid);
+        if (item != null)
         {
             item.Enchants += 5;
             item.Charges += 10;
@@ -57,7 +61,9 @@ internal sealed class ItemEnchantHandler : GamePacketHandler
     {
         long itemUid = packet.ReadLong();
 
-        if (session.Player.Inventory.Items.TryGetValue(itemUid, out Item item))
+        var inventory = session.Player.Inventory;
+        var item = inventory.GetItemByUid(itemUid);
+        if (item != null)
         {
             item.EnchantExp += 5000;
             if (item.EnchantExp >= 10000)

--- a/MapleServer2/PacketHandlers/Game/ItemExtractionHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemExtractionHandler.cs
@@ -17,12 +17,13 @@ internal sealed class ItemExtractionHandler : GamePacketHandler
         long anvilItemUid = packet.ReadLong();
         long sourceItemUid = packet.ReadLong();
 
-        if (!session.Player.Inventory.Items.ContainsKey(sourceItemUid) || !session.Player.Inventory.Items.ContainsKey(anvilItemUid))
+        var inventory = session.Player.Inventory;
+        if (!inventory.HasItemWithUid(sourceItemUid) || !inventory.HasItemWithUid(anvilItemUid))
         {
             return;
         }
 
-        Item sourceItem = session.Player.Inventory.Items[sourceItemUid];
+        var sourceItem = inventory.GetItemByUid(sourceItemUid);
 
         ItemExtractionMetadata metadata = ItemExtractionMetadataStorage.GetMetadata(sourceItem.Id);
         if (metadata == null)
@@ -30,9 +31,8 @@ internal sealed class ItemExtractionHandler : GamePacketHandler
             return;
         }
 
-        int anvilAmount = 0;
-        List<KeyValuePair<long, Item>> anvils = session.Player.Inventory.Items.Where(x => x.Value.Tag == "ItemExtraction").ToList();
-        anvils.ForEach(x => anvilAmount += x.Value.Amount);
+        var anvils = inventory.GetItemsByTag("ItemExtraction").ToArray();
+        int anvilAmount = anvils.Sum(a => a.Value.Amount);
 
         if (anvilAmount < metadata.ScrollCount)
         {

--- a/MapleServer2/PacketHandlers/Game/ItemRepackageHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ItemRepackageHandler.cs
@@ -45,8 +45,9 @@ internal sealed class ItemRepackageHandler : GamePacketHandler
         long ribbonUid = packet.ReadLong();
         long repackingItemUid = packet.ReadLong();
 
-        Item ribbon = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Uid == ribbonUid);
-        Item repackingItem = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Uid == repackingItemUid);
+        var inventory = session.Player.Inventory;
+        var ribbon = inventory.GetItemByUid(ribbonUid);
+        var repackingItem = inventory.GetItemByUid(repackingItemUid);
         if (repackingItem == null || ribbon == null)
         {
             session.Send(ItemRepackagePacket.Notice(ItemRepackageErrors.ItemInvalid));

--- a/MapleServer2/PacketHandlers/Game/MasteryHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MasteryHandler.cs
@@ -131,15 +131,16 @@ internal sealed class MasteryHandler : GamePacketHandler
     {
         List<RecipeItem> ingredients = recipe.RequiredItems;
 
+        var inventory = session.Player.Inventory;
         foreach (RecipeItem ingredient in ingredients)
         {
-            Item item = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Id == ingredient.ItemId && x.Rarity == ingredient.Rarity);
+            Item item = inventory.GetItemByItemIdAndRarity(ingredient.ItemId, ingredient.Rarity);
             if (item == null || item.Amount < ingredient.Amount)
             {
                 return false;
             }
 
-            session.Player.Inventory.ConsumeItem(session, item.Uid, ingredient.Amount);
+            inventory.ConsumeItem(session, item.Uid, ingredient.Amount);
         }
 
         return true;
@@ -185,9 +186,10 @@ internal sealed class MasteryHandler : GamePacketHandler
     {
         List<RecipeItem> ingredients = recipe.RequiredItems;
 
+        var inventory = session.Player.Inventory;
         foreach (RecipeItem ingredient in ingredients)
         {
-            Item item = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Id == ingredient.ItemId && x.Rarity == ingredient.Rarity);
+            Item item = inventory.GetItemByItemIdAndRarity(ingredient.ItemId, ingredient.Rarity);
             if (item == null || item.Amount < ingredient.Amount)
             {
                 return false;

--- a/MapleServer2/PacketHandlers/Game/MeretMarketHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/MeretMarketHandler.cs
@@ -120,12 +120,13 @@ internal sealed class MeretMarketHandler : GamePacketHandler
         long listingFee = packet.ReadLong();
 
         // TODO: Check if item is a ugc block and not an item. Find item from their block inventory
-        if (!session.Player.Inventory.Items.ContainsKey(itemUid))
+        var inventory = session.Player.Inventory;
+        if (!inventory.HasItemWithUid(itemUid))
         {
             return;
         }
 
-        Item item = session.Player.Inventory.Items[itemUid];
+        Item item = inventory.GetItemByUid(itemUid);
 
         if (item.UGC is null || item.UGC.CharacterId != session.Player.CharacterId)
         {

--- a/MapleServer2/PacketHandlers/Game/RequestItemLockHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemLockHandler.cs
@@ -56,8 +56,8 @@ internal sealed class RequestItemLockHandler : GamePacketHandler
 
     private static void HandleUpdateItem(GameSession session, PacketReader packet)
     {
-        byte mode = packet.ReadByte();
+        byte operation = packet.ReadByte();
 
-        session.Player.LockInventory.Update(session, mode);
+        session.Player.LockInventory.Update(session, operation);
     }
 }

--- a/MapleServer2/PacketHandlers/Game/RequestItemStorage.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemStorage.cs
@@ -65,7 +65,8 @@ internal sealed class RequestItemStorage : GamePacketHandler
         short slot = packet.ReadShort();
         int amount = packet.ReadInt();
 
-        if (!session.Player.Inventory.Items.ContainsKey(uid))
+        var inventory = session.Player.Inventory;
+        if (!inventory.HasItemWithUid(uid))
         {
             return;
         }

--- a/MapleServer2/PacketHandlers/Game/RequestItemUseHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemUseHandler.cs
@@ -23,12 +23,13 @@ internal sealed class RequestItemUseHandler : GamePacketHandler
     {
         long itemUid = packet.ReadLong();
 
-        if (!session.Player.Inventory.Items.ContainsKey(itemUid))
+        var inventory = session.Player.Inventory;
+        if (!inventory.HasItemWithUid(itemUid))
         {
             return;
         }
 
-        Item item = session.Player.Inventory.Items[itemUid];
+        Item item = inventory.GetItemByUid(itemUid);
 
         switch (item.Function.Name)
         {
@@ -347,12 +348,13 @@ internal sealed class RequestItemUseHandler : GamePacketHandler
     public static void HandlePetExtraction(GameSession session, PacketReader packet, Item item)
     {
         long petUid = long.Parse(packet.ReadUnicodeString());
-        if (!session.Player.Inventory.Items.ContainsKey(petUid))
+        var inventory = session.Player.Inventory;
+        if (!inventory.HasItemWithUid(petUid))
         {
             return;
         }
 
-        Item pet = session.Player.Inventory.Items[petUid];
+        Item pet = inventory.GetItemByUid(petUid);
 
         Item badge = new(70100000)
         {

--- a/MapleServer2/PacketHandlers/Game/RequestItemUseMultipleHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestItemUseMultipleHandler.cs
@@ -32,8 +32,9 @@ internal sealed class RequestItemUseMultipleHandler : GamePacketHandler
             return;
         }
 
-        Dictionary<long, Item> items = new(session.Player.Inventory.Items.Where(x => x.Value.Id == itemId)); // Make copy of items in-case new item is added
-        if (items.Count == 0)
+        var inventory = session.Player.Inventory;
+        var items = inventory.GetItemsByItemId(itemId).ToArray();
+        if (items.Length == 0)
         {
             return;
         }
@@ -55,14 +56,12 @@ internal sealed class RequestItemUseMultipleHandler : GamePacketHandler
         HandleOpenBox(session, items, /*openBox,*/ amount);
     }
 
-    private static void HandleSelectBox(GameSession session, Dictionary<long, Item> items, SelectItemBox box, int index, int amount)
+    private static void HandleSelectBox(GameSession session, IEnumerable<Item> items, SelectItemBox box, int index, int amount)
     {
         ItemDropMetadata metadata = ItemDropMetadataStorage.GetItemDropMetadata(box.BoxId);
         int opened = 0;
-        foreach (KeyValuePair<long, Item> kvp in items)
+        foreach (var item in items)
         {
-            Item item = kvp.Value;
-
             for (int i = opened; i < amount; i++)
             {
                 if (item.Amount <= 0)
@@ -75,16 +74,14 @@ internal sealed class RequestItemUseMultipleHandler : GamePacketHandler
             }
         }
 
-        session.Send(ItemUsePacket.Use(items.FirstOrDefault().Value.Id, amount));
+        session.Send(ItemUsePacket.Use(items.FirstOrDefault().Id, amount));
     }
 
-    private static void HandleOpenBox(GameSession session, Dictionary<long, Item> items, /*OpenItemBox box,*/ int amount)
+    private static void HandleOpenBox(GameSession session, IEnumerable<Item> items, /*OpenItemBox box,*/ int amount)
     {
         int opened = 0;
-        foreach (KeyValuePair<long, Item> kvp in items)
+        foreach (var item in items)
         {
-            Item item = kvp.Value;
-
             for (int i = opened; i < amount; i++)
             {
                 if (item.Amount <= 0)
@@ -97,6 +94,6 @@ internal sealed class RequestItemUseMultipleHandler : GamePacketHandler
             }
         }
 
-        session.Send(ItemUsePacket.Use(items.FirstOrDefault().Value.Id, amount));
+        session.Send(ItemUsePacket.Use(items.FirstOrDefault().Id, amount));
     }
 }

--- a/MapleServer2/PacketHandlers/Game/RequestTutorialItemHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RequestTutorialItemHandler.cs
@@ -15,11 +15,13 @@ internal sealed class RequestTutorialItemHandler : GamePacketHandler
     {
         List<TutorialItemMetadata> metadata = JobMetadataStorage.GetTutorialItems((int) session.Player.Job);
 
+        var inventory = session.Player.Inventory; 
+            
         foreach (TutorialItemMetadata tutorialItem in metadata)
         {
-            int tutorialItemsCount = session.Player.Inventory.Items.Where(x => x.Value.Id == tutorialItem.ItemId).Count();
-            tutorialItemsCount += session.Player.Inventory.Cosmetics.Where(x => x.Value.Id == tutorialItem.ItemId).Count();
-            tutorialItemsCount += session.Player.Inventory.Equips.Where(x => x.Value.Id == tutorialItem.ItemId).Count();
+            int tutorialItemsCount = inventory.GetItemCount(tutorialItem.ItemId);
+            tutorialItemsCount += inventory.Cosmetics.Where(x => x.Value.Id == tutorialItem.ItemId).Count();
+            tutorialItemsCount += inventory.Equips.Where(x => x.Value.Id == tutorialItem.ItemId).Count();
 
             if (tutorialItemsCount >= tutorialItem.Amount)
             {

--- a/MapleServer2/PacketHandlers/Game/RideHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/RideHandler.cs
@@ -56,7 +56,8 @@ internal sealed class RideHandler : GamePacketHandler
         long mountUid = packet.ReadLong();
         // [46-0s] (UgcPacketHelper.Ugc()) but client doesn't set this data?
 
-        if (type == RideType.UseItem && !session.Player.Inventory.Items.ContainsKey(mountUid))
+        var inventory = session.Player.Inventory;
+        if (type == RideType.UseItem && !inventory.HasItemWithUid(mountUid))
         {
             return;
         }
@@ -91,7 +92,8 @@ internal sealed class RideHandler : GamePacketHandler
         int mountId = packet.ReadInt();
         long mountUid = packet.ReadLong();
 
-        if (!session.Player.Inventory.Items.ContainsKey(mountUid))
+        var inventory = session.Player.Inventory;
+        if (!inventory.HasItemWithUid(mountUid))
         {
             return;
         }

--- a/MapleServer2/PacketHandlers/Game/ShopHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/ShopHandler.cs
@@ -80,7 +80,9 @@ internal sealed class ShopHandler : GamePacketHandler
         long itemUid = packet.ReadLong();
         int quantity = packet.ReadInt();
 
-        if (!session.Player.Inventory.Items.TryGetValue(itemUid, out Item item))
+        var inventory = session.Player.Inventory;
+        var item = inventory.GetItemByUid(itemUid);
+        if (item == null)
         {
             return;
         }
@@ -123,7 +125,8 @@ internal sealed class ShopHandler : GamePacketHandler
                 session.Player.Account.RemoveMerets(shopItem.Price * quantity);
                 break;
             case ShopCurrencyType.Item:
-                Item itemCost = session.Player.Inventory.Items.FirstOrDefault(x => x.Value.Id == shopItem.RequiredItemId).Value;
+                var inventory = session.Player.Inventory;
+                var itemCost = inventory.GetItemByItemId(shopItem.RequiredItemId);
                 if (itemCost.Amount < shopItem.Price)
                 {
                     return;
@@ -152,9 +155,8 @@ internal sealed class ShopHandler : GamePacketHandler
         byte unk = packet.ReadByte();
         int itemId = packet.ReadInt();
 
-        List<Item> playerInventory = new(session.Player.Inventory.Items.Values);
-
-        Item item = playerInventory.FirstOrDefault(x => x.Id == itemId);
+        var inventory = session.Player.Inventory;
+        var item = inventory.GetItemByItemId(itemId);
         if (item == null)
         {
             return;

--- a/MapleServer2/PacketHandlers/Game/SuperChatHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SuperChatHandler.cs
@@ -36,9 +36,10 @@ internal sealed class SuperChatHandler : GamePacketHandler
 
     private static void HandleSelect(GameSession session, PacketReader packet)
     {
-        int item = packet.ReadInt();
+        int itemId = packet.ReadInt();
 
-        Item superChatItem = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Id == item);
+        var inventory = session.Player.Inventory;
+        Item superChatItem = inventory.GetItemByItemId(itemId);
         if (superChatItem == null)
         {
             return;

--- a/MapleServer2/PacketHandlers/Game/SystemShopHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/SystemShopHandler.cs
@@ -51,7 +51,8 @@ internal sealed class SystemShopHandler : GamePacketHandler
 
         int itemId = packet.ReadInt();
 
-        Item item = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Id == itemId);
+        var inventory = session.Player.Inventory;
+        var item = inventory.GetItemByItemId(itemId);
         if (item == null)
         {
             return;

--- a/MapleServer2/PacketHandlers/Game/UgcHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/UgcHandler.cs
@@ -70,7 +70,8 @@ internal sealed class UgcHandler : GamePacketHandler
 
         if (useVoucher)
         {
-            Item voucher = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Tag == "FreeDesignCoupon");
+            var inventory = session.Player.Inventory;
+            var voucher = inventory.GetItemByTag("FreeDesignCoupon");
             if (voucher is null)
             {
                 return;

--- a/MapleServer2/PacketHandlers/Game/UserChatHandler.cs
+++ b/MapleServer2/PacketHandlers/Game/UserChatHandler.cs
@@ -72,8 +72,9 @@ internal sealed class UserChatHandler : GamePacketHandler
 
     private static void HandleChannelChat(GameSession session, string message, ChatType type, PacketWriter itemLinkPacket)
     {
-        Player player = session.Player;
-        Item voucher = player.Inventory.Items.Values.FirstOrDefault(x => x.Tag == "FreeChannelChatCoupon");
+        var player = session.Player;
+        var inventory = player.Inventory;
+        Item voucher = inventory.GetItemByTag("FreeChannelChatCoupon");
         if (voucher is not null)
         {
             session.Send(NoticePacket.Notice(SystemNotice.UsedChannelChatVoucher, NoticeType.ChatAndFastText));
@@ -103,7 +104,8 @@ internal sealed class UserChatHandler : GamePacketHandler
             return;
         }
 
-        Item superChatItem = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Function.Id == session.Player.SuperChat);
+        var inventory = session.Player.Inventory;
+        var superChatItem = inventory.GetItemByFunctionId(session.Player.SuperChat);
         if (superChatItem is null)
         {
             session.Player.SuperChat = 0;
@@ -124,7 +126,8 @@ internal sealed class UserChatHandler : GamePacketHandler
 
     private static void HandleWorldChat(GameSession session, string message, ChatType type, PacketWriter itemLinkPacket)
     {
-        Item voucher = session.Player.Inventory.Items.Values.FirstOrDefault(x => x.Tag == "FreeWorldChatCoupon");
+        var inventory = session.Player.Inventory;
+        var voucher = inventory.GetItemByTag("FreeWorldChatCoupon");
         if (voucher is not null)
         {
             session.Send(NoticePacket.Notice(SystemNotice.UsedWorldChatVoucher, NoticeType.ChatAndFastText));

--- a/MapleServer2/Packets/ItemLockPacket.cs
+++ b/MapleServer2/Packets/ItemLockPacket.cs
@@ -33,12 +33,12 @@ public static class ItemLockPacket
         return pWriter;
     }
 
-    public static PacketWriter UpdateItems(List<Item> items)
+    public static PacketWriter UpdateItems(IEnumerable<Item> items)
     {
         PacketWriter pWriter = PacketWriter.Of(SendOp.ITEM_LOCK);
         pWriter.Write(ItemLockMode.Update);
-        pWriter.WriteByte((byte) items.Count);
-        foreach (Item item in items)
+        pWriter.WriteByte((byte) items.Count());
+        foreach (var item in items)
         {
             pWriter.WriteLong(item.Uid);
             pWriter.WriteItem(item);

--- a/MapleServer2/Types/BankInventory.cs
+++ b/MapleServer2/Types/BankInventory.cs
@@ -37,7 +37,8 @@ public class BankInventory
 
     public void Add(GameSession session, long uid, int amount, short slot)
     {
-        Item item = session.Player.Inventory.Items[uid];
+        var inventory = session.Player.Inventory;
+        Item item = inventory.GetItemByUid(uid);
 
         if (amount < item.Amount)
         {

--- a/MapleServer2/Types/DismantleInventory.cs
+++ b/MapleServer2/Types/DismantleInventory.cs
@@ -32,16 +32,15 @@ public class DismantleInventory
 
     public void AutoAdd(GameSession session, InventoryTab inventoryTab, int rarityType)
     {
-        Dictionary<long, Item> items = session.Player.Inventory.Items;
-
-        foreach (KeyValuePair<long, Item> item in items)
+        var itemsToDismantle = session.Player.Inventory.GetItemsToDismantle(inventoryTab, rarityType);
+        foreach (var item in itemsToDismantle)
         {
-            if (item.Value.InventoryTab != inventoryTab || item.Value.Rarity > rarityType
-                || !item.Value.EnableBreak || Slots.Any(x => x != null && x.Item1 == item.Key))
+            if (Slots.Any(x => x != null && x.Item1 == item.Uid))
             {
                 continue;
             }
-            DismantleAdd(session, -1, item.Value.Uid, item.Value.Amount);
+            
+            DismantleAdd(session, -1, item.Uid, item.Amount);
         }
     }
 
@@ -95,7 +94,8 @@ public class DismantleInventory
         Rewards = new();
         foreach (Tuple<long, int> slot in Slots.Where(x => x != null))
         {
-            Item item = session.Player.Inventory.Items.FirstOrDefault(x => x.Value.Uid == slot.Item1).Value;
+            var inventory = session.Player.Inventory;
+            var item = inventory.GetItemByUid(slot.Item1);
             if (!ItemMetadataStorage.IsValid(item.Id))
             {
                 continue;

--- a/MapleServer2/Types/LockInventory.cs
+++ b/MapleServer2/Types/LockInventory.cs
@@ -44,19 +44,13 @@ public class LockInventory
         session.Send(ItemLockPacket.Remove(uid));
     }
 
-    public void Update(GameSession session, byte mode)
+    public void Update(GameSession session, byte operation)
     {
-        Dictionary<long, Item> inventory = session.Player.Inventory.Items;
-        List<Item> changedItems = new();
-        foreach (long uid in Items[mode].Where(x => x != 0))
-        {
-            if (inventory.ContainsKey(uid))
-            {
-                inventory[uid].IsLocked = mode == 0;
-                inventory[uid].UnlockTime = mode == 1 ? TimeInfo.AddDays(3) : 0;
-                changedItems.Add(inventory[uid]);
-            }
-        }
+        var inventory = session.Player.Inventory;
+
+        var itemIdsToUpdate = Items[operation].Where(x => x != 0);
+        var changedItems = inventory.LockItems(itemIdsToUpdate, operation);
+        
         session.Send(ItemLockPacket.UpdateItems(changedItems));
     }
 }


### PR DESCRIPTION
Got very lazy with this... woops

- Makes inventory items private
  - Enforces single responsibility of the inventory class, the outside world should not be allowed to mess with the state of the inventory in any way it wants.
  - Without this, it's very easy to introduce bugs to the inventory domain
  - Without this, code becomes very messy as multiple developers try to do the same thing over and over (just because they can, by nature of items being public), introducing bugs and duplicating code
  - Without this, changing the data structure of the underlying items is a very messy task
- Introduces various methods to replace duplicate code which was dipping in to the items structure at will. These methods may not be necessary in the end as some of the calling code looks iffy, but this isn't a refactoring PR.